### PR TITLE
Cuelist actions/feedbacks/variables

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -14,7 +14,8 @@ It enables seamless integration between Companion and DMXControl, allowing you t
 - **Target Port**: TCP port for manual connection to Umbra.
 - **Username & Password**: Reserved for future use.
 
-### Supported Actions (for Executor or Macro)
+## Supported Actions 
+### For Executor or Macro
 
 - **Press Button**: Press a macro or executor button (numbers 1–4).
 - **Release Button**: Release the pressed button.
@@ -22,10 +23,49 @@ It enables seamless integration between Companion and DMXControl, allowing you t
 - **Decrement Fader**: Decrease the fader value by a step size.
 - **Set Fader**: Set the fader to a specific value.
 
-### Supported Feedback
+### For Cuelists
+- **Set intensity/fade factor/speed factor**: Sets the slider value of the intensity/fade factor/speed factor slider for that cuelist to the specified value using either a fixed numeric value or a variable
+- **Run action**: Presses/Runs the selected action (PLAY, PAUSE, STOP, GO BACK, GO, REASSIGN_SCENE_NUMBERS) on the cuelist or (GO TO, GO NEXT, LOAD) on cue with specified index (0 based)
+- **Set play mode**: Sets the play mode (Once, Loop, Bounce, Random) the cuelist should play in
+
+## Supported Feedback
 
 - **Button State**: Indicates if the button is pressed.
 - **Button Name**: Displays the name of the selected button.
 - **Fader State**: Shows the current value of the fader.
 - **Fader Name**: Displays the name of the fader.
 - **Macro Image**: Displays the image associated with the macro.
+
+### For Cuelists
+- **Check state**: Indicates if the cuelist has the selected (STOPPED, PAUSED, RUNNING) state
+- **Previous/Current/Next cue**: Indicates if the cue (specified by 0 based index) is currently the previous/current/next cue
+- **Cue progress reached**: Indicates if the progress (bar in progress columne) of the cue (specified by 0 based index) reaches the selected state and value
+    - _Note_: This enables the progress updates for the selected cuelist. This will add the `cuelist_[LIST_ID]_cue_[CUE_INDEX]_[...]` variables for all cues of the cuelist.
+
+
+## Supported variables
+### For Cuelists
+Per cuelist: 
+- `cuelist_[LIST_ID]_name`: User set name of the cuelist
+- `cuelist_[LIST_ID]_currentCue`: The cue number (value of column, NOT the index) of the current cue
+- `cuelist_[LIST_ID]_nextCue`: Thecue number (value of column, NOT the index) of the next cue
+- `cuelist_[LIST_ID]_intensity`: Value of the intensity slider (0 to 1)
+- `cuelist_[LIST_ID]_fadeFactor`: Value of the fade factor/multiplier (1 = 100%)
+- `cuelist_[LIST_ID]_speedFactor`: Value of the speed factor/multiplier (1 = 100%)
+- `cuelist_[LIST_ID]_playMode`: Play mode of the cuelist as string (Once, Loop, Random, Bounce)
+
+Per cue per cuelist:
+- `cuelist_[LIST_ID]_cue_[CUE_INDEX]_number`: Cue number (value of column) for the cue at CUE_INDEX (0 based)
+- `cuelist_[LIST_ID]_cue_[CUE_INDEX]_name`: Name string of the cue at CUE_INDEX (0 based)
+
+Per cue per cuelist (ONLY IF at least 1 `Cue progress reached` feedback exists for this cuelist):
+> _Note_: Keeping these valiables updated is relatively resource intensive. They only exists if the required feedback is added, which should only be done where required.
+- `cuelist_[LIST_ID]_cue_[CUE_INDEX]_state`: The numeric state(s) of the cue (see below), ORed together
+- `cuelist_[LIST_ID]_cue_[CUE_INDEX]_stateStr`: The state(s) of the cue as string (joined by "|"), empty of none
+    - States (with numeric values): Preparing = 0x1, Prepared = 0x2, Waiting = 0x4, Fading = 0x8, Playing = 0x10, Played = 0x20, Stopping = 0x40, Stopped = 0x80
+- `cuelist_[LIST_ID]_cue_[CUE_INDEX]_progress`: Progress of cue (between 0 and 1), value of progress bar in progress column.
+    - When waiting/following/delay, fading in, fading out (outgoing/decreasing)
+- `cuelist_[LIST_ID]_cue_[CUE_INDEX]_msToWait`: Time in ms until cue is triggered
+- `cuelist_[LIST_ID]_cue_[CUE_INDEX]_fadeTimeLeft`: Time in ms left in fade (only incoming, not outgoing)
+- `cuelist_[LIST_ID]_cue_[CUE_INDEX]_delayTimeLeft`: Time in ms left in pre delay
+- `cuelist_[LIST_ID]_cue_[CUE_INDEX]_durationTimeLeft`: Time in ms n fade duration?

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"url": "git+https://github.com/bitfocus/companion-module-dmxcontrolprojects-dmxcontrol3.git"
 	},
 	"dependencies": {
-		"@companion-module/base": "~1.11.0",
+		"@companion-module/base": "~1.12.0",
 		"@deluxequadrat/dmxc-grpc-client": "^1.0.2"
 	},
 	"devDependencies": {

--- a/src/dmxcstate/repositorybase.ts
+++ b/src/dmxcstate/repositorybase.ts
@@ -1,4 +1,9 @@
-import { CompanionInputFieldDropdown, CompanionOptionValues } from "@companion-module/base";
+import { CompanionInputFieldDropdown, CompanionInputFieldTextInput, CompanionOptionValues } from "@companion-module/base";
+
+enum IdNameFieldType {
+    Dropdown = "dropdown",
+    TextVariables = "textinput",
+}
 
 export class RepositoryBase<T extends { id: string; name: string }> {
     protected data: Map<string, T> = new Map<string, T>();
@@ -51,27 +56,79 @@ export class RepositoryBase<T extends { id: string; name: string }> {
         this.data.clear();
     }
 
-    public generateIdOpion(label: string): CompanionInputFieldDropdown {
-        const allOptions = this.getAll().map(list => ({ id: list.id, label: list.name }));
-        return {
-            id: "id_or_name",
-            type: "dropdown",
-            label,
-            choices: allOptions,
-            allowCustom: true,
-            default: allOptions[0]?.id ?? ""
-        };
+    /**
+     * Generates companion input fields to allow the user to select (dropdown) or enter (text field with valiables)
+     * the id of any element in this repository
+     * 
+     * @param label The label for the id input or dropdown field
+     * @returns 3 Companion input fields (choice between dropdown/text, conditional dropdown, conditional text input)
+     */
+    public generateIdOpion(label: string): (CompanionInputFieldDropdown | CompanionInputFieldTextInput)[] {
+        const allOptions = this.getAll().map(element => ({ id: element.id, label: element.name }));
+        return [
+            {
+                type: "dropdown",
+                label: "Type of ID/name field",
+                id: "id_or_name_type",
+                default: IdNameFieldType.Dropdown,
+                choices: [
+                    { id: IdNameFieldType.Dropdown, label: "Dropdown coice" },
+                    { id: IdNameFieldType.TextVariables, label: "Text/Variables" },
+                ],
+            },
+            {
+                id: "id_or_name_choice",
+                type: "dropdown",
+                label,
+                choices: allOptions,
+                allowCustom: true,
+                default: allOptions[0]?.id ?? "",
+                isVisibleExpression: `$(options:id_or_name_type) == "${IdNameFieldType.Dropdown}"`,
+            },
+            {
+                id: "id_or_name_text",
+                type: "textinput",
+                label: label + " (with variables)",
+                default: "",
+                isVisibleExpression: `$(options:id_or_name_type) == "${IdNameFieldType.TextVariables}"`,
+                useVariables: {
+                    local: true,
+                },
+            },
+        ];
     }
 
-    public checkAndGetIdOption(options: CompanionOptionValues): T {
-        const id = options?.id_or_name;
+    /**
+     * Retrieves the selected element from this repository slected using the fields created with `generateIdOpion`
+     * 
+     * @param options The (full, unmodified) `options` object returned in the event (e.g. in an action) by companion
+     * @param parseVariablesInString The `parseVariablesInString` in the context (second param) passed to events (e.g. actions)
+     * @returns Promise resolving to the selected element
+     * @throws Rejects promise if user input couldn't be resolved to an element in this repository
+     */
+    public async checkAndGetIdOption(options: CompanionOptionValues, parseVariablesInString: (text: string) => Promise<string>): Promise<T> {
+        const id_type = options?.id_or_name_type as string;
+        if (typeof id_type !== "string") {
+            throw new Error("A valid way to input id/name must be selected: " + JSON.stringify(options));
+        }
+        let id: string;
+        switch (id_type) {
+            case IdNameFieldType.Dropdown:
+                id = options.id_or_name_choice as string;
+                break;
+            case IdNameFieldType.TextVariables:
+                id = await parseVariablesInString(options.id_or_name_text as string);
+                break;
+            default:
+                throw new Error("Unknown way to input id/name");
+        }
         if (typeof id !== "string") {
-            throw new Error("To set cuelist intensity, cuelist id and intensity must be set");
+            throw new Error("Provided id was not a string. Could not find element.");
         }
-        const list = this.getSingle(id);
-        if (list === undefined) {
-            throw new Error(`Cuelist ${id} does not exist.`);
+        const element = this.getSingle(id);
+        if (element === undefined) {
+            throw new Error(`Element ${id} does not exist.`);
         }
-        return list;
+        return element;
     }
 }

--- a/src/dmxcstate/repositorybase.ts
+++ b/src/dmxcstate/repositorybase.ts
@@ -1,3 +1,5 @@
+import { CompanionInputFieldDropdown, CompanionOptionValues } from "@companion-module/base";
+
 export class RepositoryBase<T extends { id: string; name: string }> {
     protected data: Map<string, T> = new Map<string, T>();
     protected namelookup: Map<string, string> = new Map<string, string>();
@@ -5,6 +7,20 @@ export class RepositoryBase<T extends { id: string; name: string }> {
     public add(instance: T) {
         this.data.set(instance.id, instance);
         this.namelookup.set(instance.name, instance.id);
+    }
+
+    public update(instance: Partial<T> & { id: string }) {
+        if (!this.data.has(instance.id)) {
+            this.add(instance as T);
+            return;
+        }
+        const existing = this.data.get(instance.id)!;
+        const oldName = existing.name;
+        Object.assign(existing, instance);
+        if (typeof instance.name === "string" && oldName != instance.name) {
+            this.namelookup.delete(oldName);
+            this.namelookup.set(instance.name, instance.id);
+        }
     }
 
     public getSingle(id: string): T | undefined {
@@ -33,5 +49,29 @@ export class RepositoryBase<T extends { id: string; name: string }> {
 
     public clear() {
         this.data.clear();
+    }
+
+    public generateIdOpion(label: string): CompanionInputFieldDropdown {
+        const allOptions = this.getAll().map(list => ({ id: list.id, label: list.name }));
+        return {
+            id: "id_or_name",
+            type: "dropdown",
+            label,
+            choices: allOptions,
+            allowCustom: true,
+            default: allOptions[0]?.id ?? ""
+        };
+    }
+
+    public checkAndGetIdOption(options: CompanionOptionValues): T {
+        const id = options?.id_or_name;
+        if (typeof id !== "string") {
+            throw new Error("To set cuelist intensity, cuelist id and intensity must be set");
+        }
+        const list = this.getSingle(id);
+        if (list === undefined) {
+            throw new Error(`Cuelist ${id} does not exist.`);
+        }
+        return list;
     }
 }

--- a/src/grpc/cuelistclient.ts
+++ b/src/grpc/cuelistclient.ts
@@ -1,13 +1,14 @@
 import * as GRPC from "@grpc/grpc-js";
-import { CompanionActionDefinition, CompanionActionDefinitions, CompanionActionEvent, CompanionFeedbackDefinition, CompanionFeedbackDefinitions, CompanionFeedbackInfo, CompanionOptionValues, CompanionPresetDefinitions, CompanionVariableDefinition, CompanionVariableValue } from "@companion-module/base";
+import { CompanionActionDefinition, CompanionActionDefinitions, CompanionActionEvent, CompanionFeedbackDefinition, CompanionFeedbackDefinitions, CompanionFeedbackInfo, CompanionInputFieldNumber, CompanionInputFieldTextInput, CompanionOptionValues, CompanionPresetDefinitions, CompanionVariableDefinition, CompanionVariableValue } from "@companion-module/base";
 import { IDMXCClient } from "./idmxcclient";
-import { CuelistClientClient } from "@deluxequadrat/dmxc-grpc-client/dist/index.LumosProtobufClient";
+import { CuelistClientClient, ParameterClientClient } from "@deluxequadrat/dmxc-grpc-client/dist/index.LumosProtobufClient";
 import { DMXCModuleInstance } from "../main";
 import { RepositoryBase } from "../dmxcstate/repositorybase";
 import { CuelistActionRequest, CuelistActionRequest_EAction, CuelistChangedMessage, CuelistDescriptor, CuelistProgressStateChangeMessage, CuelistProgressStateChangeRequest, ESceneListState, GetCuelistsResponse, SetCuelistValueRequest } from "@deluxequadrat/dmxc-grpc-client/dist/index.LumosProtobuf.Cuelist";
-import { ConfirmedResponse, EChangeType, GetMultipleRequest, GetRequest } from "@deluxequadrat/dmxc-grpc-client/dist/index.LumosProtobuf";
+import { ConfirmedResponse, EChangeType, GetMultipleRequest, GetParametersRequest, GetParametersResponse, GetRequest, SetTestParameterValueRequest } from "@deluxequadrat/dmxc-grpc-client/dist/index.LumosProtobuf";
 import { CompanionCommonCallbackContext } from "@companion-module/base/dist/module-api/common";
 import { CueProgressStateMessage } from "@deluxequadrat/dmxc-grpc-client/dist/index.LumosProtobuf.Cue";
+import { checkAndGetNumberOrVariable, generateNumberOrVariableField } from "../utils";
 
 // Time between requesting full cuelist updates
 // See CuelistClient.pollInterval
@@ -16,8 +17,9 @@ const CUELIST_POLL_INTERVAL = 60000;
 type VariableWithValue = CompanionVariableDefinition & { value: CompanionVariableValue };
 
 enum CuelistActions {
-    SetIntensity = "cuelist_set_intensity",
-    CuelistAction = "cuelist_action"
+    SetIntensityFadeSpeed = "cuelist_set_intensity",
+    CuelistAction = "cuelist_action",
+    CuelistSetPlayMode = "cuelist_set_play_mode",
 }
 
 enum CuelistFeedbacks {
@@ -45,9 +47,22 @@ enum ESceneState {
     Stopped = 0x80,
 }
 
+const CUE_INDEX_INPUT: CompanionInputFieldNumber = {
+    id: "cue_index",
+    label: "Cue index (0 based)",
+    tooltip: "Index of cue (0 based position of cue in cuelist), NOT cue number",
+    type: "number",
+    min: 0,
+    max: 4294967295,
+    default: 0,
+};
+const ACTIONS_REQUIRING_CUE_INDEX = [CuelistActionRequest_EAction.GO_TO, CuelistActionRequest_EAction.GO_NEXT, CuelistActionRequest_EAction.LOAD];
+
 export class CuelistClient implements IDMXCClient {
     grpcclient: CuelistClientClient;
+    paramGrpcclient: ParameterClientClient;
     repo: RepositoryBase<CuelistDescriptor>;
+    private isRunning: boolean = false;
     // Map of cuelist id to feedback id that listens to that cuelist
     private progressFeedbacks: Map<string, Set<string>>;
     private cueProgressPerCuelist: Map<string, Map<number, CueProgressStateMessage>>;
@@ -72,6 +87,10 @@ export class CuelistClient implements IDMXCClient {
         this.progressFeedbacks = new Map();
         this.cueProgressPerCuelist = new Map();
         this.grpcclient = new CuelistClientClient(
+            endpoint,
+            GRPC.credentials.createInsecure()
+        );
+        this.paramGrpcclient = new ParameterClientClient(
             endpoint,
             GRPC.credentials.createInsecure()
         );
@@ -132,7 +151,7 @@ export class CuelistClient implements IDMXCClient {
 
     private onReceiveProgressChange(progress: CuelistProgressStateChangeMessage) {
         const list = this.repo.getSingle(progress.cuelistId);
-        if (list) {
+        if (list && list.state != progress.cuelistState) {
             list.state = progress.cuelistState;
             this.setVariables(this.generateVariablesCuelistProperties(progress.cuelistId))
             this.instance.checkFeedbacks(CuelistFeedbacks.CuelistState);
@@ -150,7 +169,6 @@ export class CuelistClient implements IDMXCClient {
         this.setVariables(this.generateVariablesCueProgress(progress.cuelistId));
         const subscribers = this.progressFeedbacks.get(progress.cuelistId);
         if (subscribers) {
-            //todo: restrict checkFeedback to those actually referencing one of the updated cues
             this.instance.checkFeedbacksById(...subscribers.values())
         }
     }
@@ -170,54 +188,72 @@ export class CuelistClient implements IDMXCClient {
     }
 
     async startClient(updatePresets: () => void, updateActions: () => void, updateFeedbacks: () => void, updateVariables: () => void) {
+        this.isRunning = true;
         this.updatePresets = updatePresets;
         this.updateActions = updateActions;
         this.updateFeedbacks = updateFeedbacks;
         this.updateVariables = updateVariables;
         try {
-            this.changeStream = this.grpcclient.receiveCuelistChanges(
-                GetRequest.create({ requestId: this.instance.getRequestId() }),
-                this.metadata
-            );
-            this.changeStream.on("data", (response: CuelistChangedMessage) => {
-                switch (response.changeType) {
-                    case EChangeType.Added:
-                        if (response.cuelistData) {
-                            this.repo.add(response.cuelistData);
-                            this.onCuelistAddedRemoved();
-                        }
-                        break;
-                    case EChangeType.Changed:
-                        if (response.cuelistData) {
-                            this.onReceiveCuelistChanged(response.cuelistData);
-                        }
-                        break;
-                    case EChangeType.Removed:
-                        let removedId = response.cuelistId || response.cuelistData?.id;
-                        if (removedId) {
-                            this.repo.remove(removedId);
-                            this.cueProgressPerCuelist.delete(removedId);
-                            this.onCuelistAddedRemoved();
-                        }
-                        break;
-                }
-            });
-            this.changeStream.on("error", (error) => {
-                this.instance.log("error", "In cuelist changes stream: " + error.name);
-            });
-            this.changeStream.on("close", () => {
-                this.instance.log("warn", "Cuelist changed stream was closed");
-                //todo: reopen
-            });
+            if (this.changeStream == null || this.changeStream.closed) {
+                this.changeStream = this.grpcclient.receiveCuelistChanges(
+                    GetRequest.create({ requestId: this.instance.getRequestId() }),
+                    this.metadata
+                );
+                this.changeStream.on("data", (response: CuelistChangedMessage) => {
+                    switch (response.changeType) {
+                        case EChangeType.Added:
+                            if (response.cuelistData) {
+                                this.repo.add(response.cuelistData);
+                                this.onCuelistAddedRemoved();
+                            }
+                            break;
+                        case EChangeType.Changed:
+                            if (response.cuelistData) {
+                                this.onReceiveCuelistChanged(response.cuelistData);
+                            }
+                            break;
+                        case EChangeType.Removed:
+                            let removedId = response.cuelistId || response.cuelistData?.id;
+                            if (removedId) {
+                                this.repo.remove(removedId);
+                                this.cueProgressPerCuelist.delete(removedId);
+                                this.onCuelistAddedRemoved();
+                            }
+                            break;
+                    }
+                });
+                this.changeStream.on("error", (error) => {
+                    this.instance.log("error", "In cuelist changes stream: " + error.name);
+                });
+                this.changeStream.on("close", () => {
+                    this.instance.log("warn", "Cuelist changed stream was closed");
+                    if (this.isRunning) {
+                        this.instance.log("warn", "Attempting to reopen");
+                        this.startClient(this.updatePresets, updateActions, updateFeedbacks, updateVariables);
+                    }
+                });
+            } else {
+                this.instance.log("info", "Not opening cuelist changed stream as it seems to be already open");
+            }
 
-            this.progressStream = this.grpcclient.receiveCuelistProgressChanges(this.metadata);
-            this.progressStream.on("data", (progress: CuelistProgressStateChangeMessage) => {
-                this.onReceiveProgressChange(progress);
-            });
-            this.progressStream.on("close", () => {
-                this.instance.log("warn", "Cuelist progress stream was closed");
-                //todo: reopen
-            });
+            if (this.progressStream == null || this.progressStream.closed) {
+                // If stream is newly opened, ensure all subscriptions are sent to server by unsubscribing and then resubscribing all
+                this.instance.unsubscribeFeedbacks(CuelistFeedbacks.CueProgress);
+
+                this.progressStream = this.grpcclient.receiveCuelistProgressChanges(this.metadata);
+                this.progressStream.on("data", (progress: CuelistProgressStateChangeMessage) => {
+                    this.onReceiveProgressChange(progress);
+                });
+                this.progressStream.on("close", () => {
+                    this.instance.log("warn", "Cuelist progress stream was closed");
+                    if (this.isRunning) {
+                        this.instance.log("warn", "Attempting to reopen");
+                        this.startClient(this.updatePresets, updateActions, updateFeedbacks, updateVariables);
+                    }
+                });
+            } else {
+                this.instance.log("info", "Not opening cuelist progress stream as it seems to be already open");
+            }
 
             if (this.pollInterval == null) {
                 this.pollInterval = setInterval(this.getAllCuelists.bind(this, true), CUELIST_POLL_INTERVAL);
@@ -228,31 +264,37 @@ export class CuelistClient implements IDMXCClient {
         }
     }
 
+
+
     generateActions(): CompanionActionDefinitions {
         this.instance.log("debug", "Reloading cuelist actions");
 
         const actions: Record<CuelistActions, CompanionActionDefinition> = {
-            [CuelistActions.SetIntensity]: {
-                name: "Cuelist: Set intensity",
-                description: "Set the intensity slider value of a cuelist (Same effect as if executor with fader set to intensity)",
+            [CuelistActions.SetIntensityFadeSpeed]: {
+                name: "Cuelist: Set intensity/fade factor/speed factor",
+                description: "Set the value of the intensity/fade factor/speed factor slider of a cuelist (Same effect as if executor with fader set to that mode)",
                 options: [
-                    this.repo.generateIdOpion("Cuelist ID or name"),
+                    ...this.repo.generateIdOpion("Cuelist ID or name"),
                     {
-                        id: "intensity",
-                        type: "number",
-                        label: "Intensity (%)",
-                        min: 0,
-                        max: 100,
-                        default: 100,
-                    }
+                        id: "slider_to_change",
+                        type: "dropdown",
+                        label: "Slider",
+                        choices: [
+                            { id: "intensity", label: "Intensity" },
+                            { id: "fade", label: "Fade Factor" },
+                            { id: "speed", label: "Speed Factor" },
+                        ],
+                        default: "intensity",
+                    },
+                    ...generateNumberOrVariableField("Value (%)", 0, 1000, 100),
                 ],
-                callback: this.onActionSetIntensity.bind(this)
+                callback: this.onActionSetIntensityFadeSpeed.bind(this)
             },
             [CuelistActions.CuelistAction]: {
                 name: "Cuelist: Run Action",
                 description: "Run an action (e.g. GO, STOP, ...) on a cuelist",
                 options: [
-                    this.repo.generateIdOpion("Cuelist ID or name"),
+                    ...this.repo.generateIdOpion("Cuelist ID or name"),
                     {
                         id: "actionType",
                         label: "Action Type",
@@ -262,17 +304,44 @@ export class CuelistClient implements IDMXCClient {
                             { id: "PAUSE", label: "Pause" },
                             { id: "STOP", label: "Stop" },
                             { id: "GO_BACK", label: "Go Back" },
-                            //{id: "GO_TO", label: "Go To"},
+                            { id: "GO_TO", label: "Go To" },
                             { id: "GO_NEXT", label: "Go Next" },
                             { id: "GO", label: "Go" },
                             { id: "LOAD", label: "Load" },
                             { id: "REASSIGN_SCENE_NUMBERS", label: "Reassign scene numbers" },
                         ] as { id: keyof typeof CuelistActionRequest_EAction, label: string }[],
                         default: "GO",
+                    },
+                    {
+                        ...CUE_INDEX_INPUT,
+                        isVisibleExpression: `arrayIncludes([${Object.entries(CuelistActionRequest_EAction)
+                            .filter(([_, actionVal]) => ACTIONS_REQUIRING_CUE_INDEX.includes(actionVal as any))
+                            .map(([actionStr, _]) => '"' + actionStr + '"').join(",")
+                            }], $(options:actionType))`
                     }
                 ],
                 callback: this.onActionCuelistAction.bind(this)
-            }
+            },
+            [CuelistActions.CuelistSetPlayMode]: {
+                name: "Cuelist: Set play mode",
+                description: "Set the play mode of the cuelist",
+                options: [
+                    ...this.repo.generateIdOpion("Cuelist ID or name"),
+                    {
+                        id: "play_mode",
+                        type: "dropdown",
+                        label: "Play Mode",
+                        choices: [
+                            { id: "Once", label: "Once" },
+                            { id: "Loop", label: "Loop" },
+                            { id: "Bounce", label: "Bounce" },
+                            { id: "Random", label: "Random" },
+                        ] as { id: keyof typeof ESceneListPlayMode, label: string }[],
+                        default: "Once",
+                    },
+                ],
+                callback: this.onActionSetPlayMode.bind(this)
+            },
         };
         return actions;
     }
@@ -283,7 +352,7 @@ export class CuelistClient implements IDMXCClient {
                 type: "boolean",
                 name: "Cuelist: Check state",
                 options: [
-                    this.repo.generateIdOpion("Cuelist ID or name"),
+                    ...this.repo.generateIdOpion("Cuelist ID or name"),
                     {
                         id: "state",
                         label: "Cuelist state",
@@ -305,16 +374,8 @@ export class CuelistClient implements IDMXCClient {
                 type: "boolean",
                 name: "Cuelist: Previous/Current/Next cue",
                 options: [
-                    this.repo.generateIdOpion("Cuelist ID or name"),
-                    {
-                        id: "cue_index",
-                        label: "Cue index (0 based)",
-                        tooltip: "Index of cue (0 based position of cue in cuelist), NOT cue number",
-                        type: "number",
-                        min: 0,
-                        max: 4294967295,
-                        default: 0,
-                    },
+                    ...this.repo.generateIdOpion("Cuelist ID or name"),
+                    CUE_INDEX_INPUT,
                     {
                         id: "cue_state",
                         label: "Cue is ...",
@@ -337,16 +398,8 @@ export class CuelistClient implements IDMXCClient {
                 name: "Cuelist: Cue progress reached",
                 description: "Check if a cue has reached a certain point in its progress. Adding this feedback will subscribe to the progress of the selected cuelist and add variables for its progress",
                 options: [
-                    this.repo.generateIdOpion("Cuelist ID or name"),
-                    {
-                        id: "cue_index",
-                        label: "Cue index (0 based)",
-                        tooltip: "Index of cue (0 based position of cue in cuelist), NOT cue number",
-                        type: "number",
-                        min: 0,
-                        max: 4294967295,
-                        default: 0,
-                    },
+                    ...this.repo.generateIdOpion("Cuelist ID or name"),
+                    CUE_INDEX_INPUT,
                     {
                         id: "cue_progress_state",
                         label: "Cue state",
@@ -450,7 +503,7 @@ export class CuelistClient implements IDMXCClient {
                 { variableId: `cuelist_${list.id}_cue_${i}_msToWait`, name: `Cuelist ${list.name} cue ${cue.cueNumber?.number.join(".")} time in ms until cue is triggered`, value: cueProgress?.msToWait ?? -1 },
                 { variableId: `cuelist_${list.id}_cue_${i}_fadeTimeLeft`, name: `Cuelist ${list.name} cue ${cue.cueNumber?.number.join(".")} time left in fade (only on incoming) in ms`, value: cueProgress?.fadeTimeLeft ?? -1 },
                 { variableId: `cuelist_${list.id}_cue_${i}_delayTimeLeft`, name: `Cuelist ${list.name} cue ${cue.cueNumber?.number.join(".")} time left in pre delay in ms`, value: cueProgress?.delayTimeLeft ?? -1 },
-                { variableId: `cuelist_${list.id}_cue_${i}_durationTimeLeft`, name: `Cuelist ${list.name} cue ${cue.cueNumber?.number.join(".")} state`, value: cueProgress?.durationTimeLeft ?? -1 },
+                { variableId: `cuelist_${list.id}_cue_${i}_durationTimeLeft`, name: `Cuelist ${list.name} cue ${cue.cueNumber?.number.join(".")} duration time in ms`, value: cueProgress?.durationTimeLeft ?? -1 },
             ]
         })
     }
@@ -465,6 +518,7 @@ export class CuelistClient implements IDMXCClient {
     }
 
     close(): void {
+        this.isRunning = false;
         if (this.pollInterval != null) {
             clearInterval(this.pollInterval);
             this.pollInterval = null;
@@ -475,20 +529,20 @@ export class CuelistClient implements IDMXCClient {
         this.grpcclient.close();
     }
 
-    private async onActionSetIntensity(event: CompanionActionEvent) {
+    private async onActionSetIntensityFadeSpeed(event: CompanionActionEvent, ctx: CompanionCommonCallbackContext) {
         try {
-            const intensity = event.options?.intensity as number;
-            if (typeof intensity !== "number") {
-                throw new Error("To set cuelist intensity, cuelist id and intensity must be set");
-            }
-            const list = this.repo.checkAndGetIdOption(event.options);
+            const max = event.options.slider_to_change == "intensity" ? 100 : 1000;
+            const value = await checkAndGetNumberOrVariable(0, max, event.options, ctx.parseVariablesInString);
+            const list = await this.repo.checkAndGetIdOption(event.options, ctx.parseVariablesInString);
 
             const actionRes = await new Promise<ConfirmedResponse>((resolve, reject) =>
                 this.grpcclient.setCuelistValue(
                     SetCuelistValueRequest.create({
                         requestId: this.instance.getRequestId(),
                         cuelistId: list.id,
-                        intensity: intensity / 100
+                        intensity: event.options.slider_to_change == "intensity" ? value / 100 : undefined,
+                        fadeFactor: event.options.slider_to_change == "fade" ? value / 100 : undefined,
+                        speedFactor: event.options.slider_to_change == "speed" ? value / 100 : undefined,
                     }),
                     this.metadata,
                     (err, res) => err != null ? reject(err) : resolve(res)
@@ -502,7 +556,7 @@ export class CuelistClient implements IDMXCClient {
         }
     }
 
-    private async onActionCuelistAction(event: CompanionActionEvent) {
+    private async onActionCuelistAction(event: CompanionActionEvent, ctx: CompanionCommonCallbackContext) {
         try {
             const actionStr = event.options?.actionType as keyof typeof CuelistActionRequest_EAction | undefined;
             if (typeof actionStr !== "string") {
@@ -512,7 +566,14 @@ export class CuelistClient implements IDMXCClient {
             if (!action) {
                 throw new Error(`Cuelist action ${actionStr} does not exist.`);
             }
-            const list = this.repo.checkAndGetIdOption(event.options)
+            const cueIndex = (event.options[CUE_INDEX_INPUT.id] ?? 0) as number;
+            if (typeof cueIndex !== "number" || cueIndex < 0) {
+                if (ACTIONS_REQUIRING_CUE_INDEX.includes(action)) {
+                    throw new Error(`For action ${actionStr} a valid cue number >= 0 is required.`);
+                }
+            }
+
+            const list = await this.repo.checkAndGetIdOption(event.options, ctx.parseVariablesInString)
 
             const actionRes = await new Promise<ConfirmedResponse>((resolve, reject) =>
                 this.grpcclient.cuelistAction(
@@ -520,6 +581,7 @@ export class CuelistClient implements IDMXCClient {
                         requestId: this.instance.getRequestId(),
                         cuelistId: list.id,
                         action: action,
+                        index: ACTIONS_REQUIRING_CUE_INDEX.includes(action) ? cueIndex : 0
                     }),
                     this.metadata,
                     (err, res) => err != null ? reject(err) : resolve(res)
@@ -533,7 +595,59 @@ export class CuelistClient implements IDMXCClient {
         }
     }
 
-    private onFeedbackCuelistState(feedback: CompanionFeedbackInfo, _: CompanionCommonCallbackContext): boolean {
+    /**
+     * Setting the play mode requires a bit of a workaround by quering the PlayMode parameter and its allowed enum values
+     * and then searching for the string of the requested mode in the returned values as the kernel returns .NET serialized objects
+     * wich we can't (easily) parse in typescript
+     */
+    private async onActionSetPlayMode(event: CompanionActionEvent, ctx: CompanionCommonCallbackContext) {
+        try {
+            const mode = event.options?.play_mode as keyof typeof ESceneListPlayMode | undefined;
+            if (typeof mode !== "string") {
+                throw new Error("Not a valid play mode to be set");
+            }
+            const list = await this.repo.checkAndGetIdOption(event.options, ctx.parseVariablesInString)
+
+            const getParam = await new Promise<GetParametersResponse>((resolve, reject) =>
+                this.paramGrpcclient.getParameters(
+                    GetParametersRequest.create({
+                        id: list.id,
+                        type: "SceneList",
+                        nameFilter: ["PlayMode"],
+                    }),
+                    this.metadata,
+                    (err, res) => err != null ? reject(err) : resolve(res)
+                ));
+            if (getParam.parameters.length != 1) {
+                throw new Error("Couldn't find one parameter named PlayMode for SceneList " + list.id);
+            }
+            const param = getParam.parameters[0];
+            // hacky solution to search in the stringified .net object, but with unique names, this should work and is less effort than parsing the serialized .NET object
+            const value = param.enumValues.find(v => v.ienum?.fallback?.fallbackNet?.toString("utf-8")?.includes(mode) || v.obj?.fallbackNet?.toString("utf-8")?.includes(mode))
+            if (!value) {
+                throw new Error("Couldn't find matching value for mode " + mode);
+            }
+            console.log("Sending", param, value);
+            const setRes = await new Promise<ConfirmedResponse>((resolve, reject) =>
+                this.paramGrpcclient.setParameterValue(
+                    SetTestParameterValueRequest.create({
+                        id: list.id,
+                        parameter: getParam.parameters[0],
+                        value: value.ienum?.fallback ?? value.obj,
+                    }),
+                    this.metadata,
+                    (err, res) => err != null ? reject(err) : resolve(res)
+                ));
+
+            if (!setRes.ok) {
+                this.instance.log("error", "While setting cuelist play mode: " + JSON.stringify(setRes.message))
+            }
+        } catch (err) {
+            this.instance.log("warn", (err as Error)?.message);
+        }
+    }
+
+    private async onFeedbackCuelistState(feedback: CompanionFeedbackInfo, ctx: CompanionCommonCallbackContext): Promise<boolean> {
         try {
             const stateStr = feedback.options.state as keyof typeof ESceneListState;
             if (typeof stateStr !== "string") {
@@ -543,7 +657,7 @@ export class CuelistClient implements IDMXCClient {
             if (typeof state !== typeof ESceneListState.STOPPED) {
                 throw new Error(`Unknown cuelist state ${stateStr}`);
             }
-            const list = this.repo.checkAndGetIdOption(feedback.options);
+            const list = await this.repo.checkAndGetIdOption(feedback.options, ctx.parseVariablesInString);
             return list.state == state;
         } catch (err) {
             this.instance.log("warn", (err as Error)?.message);
@@ -551,7 +665,7 @@ export class CuelistClient implements IDMXCClient {
         }
     }
 
-    private onFeedbackCurrentCue(feedback: CompanionFeedbackInfo, _: CompanionCommonCallbackContext): boolean {
+    private async onFeedbackCurrentCue(feedback: CompanionFeedbackInfo, ctx: CompanionCommonCallbackContext): Promise<boolean> {
         try {
             const cueState = feedback.options.cue_state as string;
             if (!["previous", "current", "next"].includes(cueState)) {
@@ -561,7 +675,7 @@ export class CuelistClient implements IDMXCClient {
             if (typeof cueIndex !== "number") {
                 throw new Error(`Cue index to check must be number`);
             }
-            const list = this.repo.checkAndGetIdOption(feedback.options);
+            const list = await this.repo.checkAndGetIdOption(feedback.options, ctx.parseVariablesInString);
             switch (cueState) {
                 case "previous":
                     return list.previousIndex == cueIndex;
@@ -598,10 +712,10 @@ export class CuelistClient implements IDMXCClient {
         return { cueProgressState, cueIndex, cueProgress, comparisonOperator };
     }
 
-    private onFeedbackCueProgress(feedback: CompanionFeedbackInfo, _: CompanionCommonCallbackContext): boolean {
+    private async onFeedbackCueProgress(feedback: CompanionFeedbackInfo, ctx: CompanionCommonCallbackContext): Promise<boolean> {
         try {
             const { cueProgressState, cueIndex, cueProgress, comparisonOperator } = this.onFeedbackCueProgressCheckOptions(feedback.options);
-            const list = this.repo.checkAndGetIdOption(feedback.options);
+            const list = await this.repo.checkAndGetIdOption(feedback.options, ctx.parseVariablesInString);
 
             const listProgress = this.cueProgressPerCuelist.get(list.id);
             if (!listProgress) {
@@ -630,9 +744,9 @@ export class CuelistClient implements IDMXCClient {
         }
     }
 
-    private async onFeedbackCueProgressSubscribe(feedback: CompanionFeedbackInfo, _: CompanionCommonCallbackContext) {
+    private async onFeedbackCueProgressSubscribe(feedback: CompanionFeedbackInfo, ctx: CompanionCommonCallbackContext) {
         try {
-            const list = this.repo.checkAndGetIdOption(feedback.options);
+            const list = await this.repo.checkAndGetIdOption(feedback.options, ctx.parseVariablesInString);
             const subscribedFeedbacks = this.progressFeedbacks.get(list.id) ?? new Set();
             if (!this.progressFeedbacks.has(list.id)) {
                 this.progressFeedbacks.set(list.id, subscribedFeedbacks);
@@ -656,9 +770,9 @@ export class CuelistClient implements IDMXCClient {
         }
     }
 
-    private async onFeedbackCueProgressUnsubscribe(feedback: CompanionFeedbackInfo, _: CompanionCommonCallbackContext) {
+    private async onFeedbackCueProgressUnsubscribe(feedback: CompanionFeedbackInfo, ctx: CompanionCommonCallbackContext) {
         try {
-            const list = this.repo.checkAndGetIdOption(feedback.options);
+            const list = await this.repo.checkAndGetIdOption(feedback.options, ctx.parseVariablesInString);
             const subscribedFeedbacks = this.progressFeedbacks.get(list.id);
             this.instance.log("debug", `Feedback ${feedback.id} unsubscribed from ${list.id} progress`);
             if (!subscribedFeedbacks) {

--- a/src/grpc/cuelistclient.ts
+++ b/src/grpc/cuelistclient.ts
@@ -1,0 +1,680 @@
+import * as GRPC from "@grpc/grpc-js";
+import { CompanionActionDefinition, CompanionActionDefinitions, CompanionActionEvent, CompanionFeedbackDefinition, CompanionFeedbackDefinitions, CompanionFeedbackInfo, CompanionOptionValues, CompanionPresetDefinitions, CompanionVariableDefinition, CompanionVariableValue } from "@companion-module/base";
+import { IDMXCClient } from "./idmxcclient";
+import { CuelistClientClient } from "@deluxequadrat/dmxc-grpc-client/dist/index.LumosProtobufClient";
+import { DMXCModuleInstance } from "../main";
+import { RepositoryBase } from "../dmxcstate/repositorybase";
+import { CuelistActionRequest, CuelistActionRequest_EAction, CuelistChangedMessage, CuelistDescriptor, CuelistProgressStateChangeMessage, CuelistProgressStateChangeRequest, ESceneListState, GetCuelistsResponse, SetCuelistValueRequest } from "@deluxequadrat/dmxc-grpc-client/dist/index.LumosProtobuf.Cuelist";
+import { ConfirmedResponse, EChangeType, GetMultipleRequest, GetRequest } from "@deluxequadrat/dmxc-grpc-client/dist/index.LumosProtobuf";
+import { CompanionCommonCallbackContext } from "@companion-module/base/dist/module-api/common";
+import { CueProgressStateMessage } from "@deluxequadrat/dmxc-grpc-client/dist/index.LumosProtobuf.Cue";
+
+// Time between requesting full cuelist updates
+// See CuelistClient.pollInterval
+const CUELIST_POLL_INTERVAL = 60000;
+
+type VariableWithValue = CompanionVariableDefinition & { value: CompanionVariableValue };
+
+enum CuelistActions {
+    SetIntensity = "cuelist_set_intensity",
+    CuelistAction = "cuelist_action"
+}
+
+enum CuelistFeedbacks {
+    CuelistState = "cuelist_state",
+    IsCurrentCue = "cuelist_is_current_cue",
+    CueProgress = "cuelist_cue_progress",
+}
+
+enum ESceneListPlayMode {
+    Once = 0,
+    Loop = 1,
+    Random = 2,
+    Bounce = 3,
+}
+
+enum ESceneState {
+    None = 0x0,
+    Preparing = 0x1,
+    Prepared = 0x2,
+    Waiting = 0x4,
+    Fading = 0x8,
+    Playing = 0x10,
+    Played = 0x20,
+    Stopping = 0x40,
+    Stopped = 0x80,
+}
+
+export class CuelistClient implements IDMXCClient {
+    grpcclient: CuelistClientClient;
+    repo: RepositoryBase<CuelistDescriptor>;
+    // Map of cuelist id to feedback id that listens to that cuelist
+    private progressFeedbacks: Map<string, Set<string>>;
+    private cueProgressPerCuelist: Map<string, Map<number, CueProgressStateMessage>>;
+
+    private changeStream: GRPC.ClientReadableStream<CuelistChangedMessage> | null = null;
+    private progressStream: GRPC.ClientDuplexStream<CuelistProgressStateChangeRequest, CuelistProgressStateChangeMessage> | null = null;
+    // Interval for polling all cuelists to receive changes not sent via changeStream (e.g. cue renames)
+    // As those changes aren't (as) time critical it is less load to poll it once in a while than to maintain and update streams for all cues etc.
+    private pollInterval: ReturnType<typeof setInterval> | null = null;
+
+    private updatePresets = () => { };
+    private updateActions = () => { };
+    private updateFeedbacks = () => { };
+    private updateVariables = () => { };
+
+    constructor(
+        endpoint: string,
+        private metadata: GRPC.Metadata,
+        private instance: DMXCModuleInstance
+    ) {
+        this.repo = new RepositoryBase<CuelistDescriptor>();
+        this.progressFeedbacks = new Map();
+        this.cueProgressPerCuelist = new Map();
+        this.grpcclient = new CuelistClientClient(
+            endpoint,
+            GRPC.credentials.createInsecure()
+        );
+    }
+
+    private onCuelistAddedRemoved(onlyCueChanges: boolean = false) {
+        if (!onlyCueChanges) {
+            this.instance.subscribeFeedbacks(CuelistFeedbacks.CueProgress);
+            this.updateActions();
+            this.updatePresets();
+            this.updateFeedbacks();
+            this.updateVariables();
+        }
+        this.setVariables(this.repo.getIds().flatMap(id => this.generateVariablesCuelistProperties(id)));
+        this.setVariables([...this.progressFeedbacks.entries()]
+            .filter(([_, feedbacks]) => feedbacks.size > 0)
+            .flatMap(([cuelistId, _]) => this.generateVariablesCueProgress(cuelistId))
+        );
+        this.instance.checkFeedbacks(
+            CuelistFeedbacks.CuelistState,
+            CuelistFeedbacks.IsCurrentCue,
+            CuelistFeedbacks.CueProgress,
+        );
+    }
+
+    private onReceiveCuelistChanged(list: CuelistDescriptor) {
+        const oldList = this.repo.getSingle(list.id);
+        const feedbacksForList = this.progressFeedbacks.get(list.id);
+        let nameWasChanged = false;
+
+        if (oldList && oldList?.name != list.name) {
+            this.instance.unsubscribeFeedbacks(CuelistFeedbacks.CueProgress);
+            nameWasChanged = true;
+        }
+
+        if (!list.containsCues) {
+            const { cues, containsCues, ...listWithoutCues } = list;
+            this.repo.update({ ...listWithoutCues, containsCues: true });
+        } else {
+            this.repo.update(list);
+
+            if (!nameWasChanged && feedbacksForList && feedbacksForList.size > 0) {
+                this.updateVariables();
+                this.setVariables(this.generateVariablesCueProgress(list.id));
+            }
+        }
+
+        if (nameWasChanged) {
+            this.onCuelistAddedRemoved();
+        } else {
+            this.setVariables(this.generateVariablesCuelistProperties(list.id));
+            this.instance.checkFeedbacks(
+                CuelistFeedbacks.CuelistState,
+                CuelistFeedbacks.IsCurrentCue,
+            );
+        }
+    }
+
+    private onReceiveProgressChange(progress: CuelistProgressStateChangeMessage) {
+        const list = this.repo.getSingle(progress.cuelistId);
+        if (list) {
+            list.state = progress.cuelistState;
+            this.setVariables(this.generateVariablesCuelistProperties(progress.cuelistId))
+            this.instance.checkFeedbacks(CuelistFeedbacks.CuelistState);
+        }
+        const cuesOfList = this.cueProgressPerCuelist.get(progress.cuelistId) ?? new Map<number, CueProgressStateMessage>();
+        if (!this.cueProgressPerCuelist.has(progress.cuelistId)) {
+            this.cueProgressPerCuelist.set(progress.cuelistId, cuesOfList);
+        }
+        for (const i in progress.cueProgressState) {
+            if (Object.prototype.hasOwnProperty.call(progress.cueProgressState, i)) {
+                const cueProgress = progress.cueProgressState[i];
+                cuesOfList.set(cueProgress.cueIndex, cueProgress);
+            }
+        }
+        this.setVariables(this.generateVariablesCueProgress(progress.cuelistId));
+        const subscribers = this.progressFeedbacks.get(progress.cuelistId);
+        if (subscribers) {
+            //todo: restrict checkFeedback to those actually referencing one of the updated cues
+            this.instance.checkFeedbacksById(...subscribers.values())
+        }
+    }
+
+    private async getAllCuelists(onlyCueChanges?: boolean) {
+        const cuelistRes = await new Promise<GetCuelistsResponse>((resolve, reject) => this.grpcclient.getCuelists(GetMultipleRequest.create({
+            requestId: this.instance.getRequestId()
+        }),
+            this.metadata,
+            (err, res) => err != null ? reject(err) : resolve(res)
+        ));
+        for (const cuelist of cuelistRes.cuelists) {
+            this.repo.update(cuelist);
+        }
+
+        this.onCuelistAddedRemoved(onlyCueChanges);
+    }
+
+    async startClient(updatePresets: () => void, updateActions: () => void, updateFeedbacks: () => void, updateVariables: () => void) {
+        this.updatePresets = updatePresets;
+        this.updateActions = updateActions;
+        this.updateFeedbacks = updateFeedbacks;
+        this.updateVariables = updateVariables;
+        try {
+            this.changeStream = this.grpcclient.receiveCuelistChanges(
+                GetRequest.create({ requestId: this.instance.getRequestId() }),
+                this.metadata
+            );
+            this.changeStream.on("data", (response: CuelistChangedMessage) => {
+                switch (response.changeType) {
+                    case EChangeType.Added:
+                        if (response.cuelistData) {
+                            this.repo.add(response.cuelistData);
+                            this.onCuelistAddedRemoved();
+                        }
+                        break;
+                    case EChangeType.Changed:
+                        if (response.cuelistData) {
+                            this.onReceiveCuelistChanged(response.cuelistData);
+                        }
+                        break;
+                    case EChangeType.Removed:
+                        let removedId = response.cuelistId || response.cuelistData?.id;
+                        if (removedId) {
+                            this.repo.remove(removedId);
+                            this.cueProgressPerCuelist.delete(removedId);
+                            this.onCuelistAddedRemoved();
+                        }
+                        break;
+                }
+            });
+            this.changeStream.on("error", (error) => {
+                this.instance.log("error", "In cuelist changes stream: " + error.name);
+            });
+            this.changeStream.on("close", () => {
+                this.instance.log("warn", "Cuelist changed stream was closed");
+                //todo: reopen
+            });
+
+            this.progressStream = this.grpcclient.receiveCuelistProgressChanges(this.metadata);
+            this.progressStream.on("data", (progress: CuelistProgressStateChangeMessage) => {
+                this.onReceiveProgressChange(progress);
+            });
+            this.progressStream.on("close", () => {
+                this.instance.log("warn", "Cuelist progress stream was closed");
+                //todo: reopen
+            });
+
+            if (this.pollInterval == null) {
+                this.pollInterval = setInterval(this.getAllCuelists.bind(this, true), CUELIST_POLL_INTERVAL);
+            }
+            await this.getAllCuelists();
+        } catch (err) {
+            this.instance.log("error", "While getting cuelists: " + (err as GRPC.ServiceError)?.message);
+        }
+    }
+
+    generateActions(): CompanionActionDefinitions {
+        this.instance.log("debug", "Reloading cuelist actions");
+
+        const actions: Record<CuelistActions, CompanionActionDefinition> = {
+            [CuelistActions.SetIntensity]: {
+                name: "Cuelist: Set intensity",
+                description: "Set the intensity slider value of a cuelist (Same effect as if executor with fader set to intensity)",
+                options: [
+                    this.repo.generateIdOpion("Cuelist ID or name"),
+                    {
+                        id: "intensity",
+                        type: "number",
+                        label: "Intensity (%)",
+                        min: 0,
+                        max: 100,
+                        default: 100,
+                    }
+                ],
+                callback: this.onActionSetIntensity.bind(this)
+            },
+            [CuelistActions.CuelistAction]: {
+                name: "Cuelist: Run Action",
+                description: "Run an action (e.g. GO, STOP, ...) on a cuelist",
+                options: [
+                    this.repo.generateIdOpion("Cuelist ID or name"),
+                    {
+                        id: "actionType",
+                        label: "Action Type",
+                        type: "dropdown",
+                        choices: [
+                            { id: "PLAY", label: "Play" },
+                            { id: "PAUSE", label: "Pause" },
+                            { id: "STOP", label: "Stop" },
+                            { id: "GO_BACK", label: "Go Back" },
+                            //{id: "GO_TO", label: "Go To"},
+                            { id: "GO_NEXT", label: "Go Next" },
+                            { id: "GO", label: "Go" },
+                            { id: "LOAD", label: "Load" },
+                            { id: "REASSIGN_SCENE_NUMBERS", label: "Reassign scene numbers" },
+                        ] as { id: keyof typeof CuelistActionRequest_EAction, label: string }[],
+                        default: "GO",
+                    }
+                ],
+                callback: this.onActionCuelistAction.bind(this)
+            }
+        };
+        return actions;
+    }
+
+    generateFeedbacks(): CompanionFeedbackDefinitions {
+        const feedbacks: Record<CuelistFeedbacks, CompanionFeedbackDefinition> = {
+            [CuelistFeedbacks.CuelistState]: {
+                type: "boolean",
+                name: "Cuelist: Check state",
+                options: [
+                    this.repo.generateIdOpion("Cuelist ID or name"),
+                    {
+                        id: "state",
+                        label: "Cuelist state",
+                        type: "dropdown",
+                        choices: [
+                            { id: "STOPPED", label: "Stopped" },
+                            { id: "PAUSED", label: "Paused" },
+                            { id: "RUNNING", label: "Running" },
+                        ] as { id: keyof typeof ESceneListState, label: string }[],
+                        default: "RUNNING",
+                    },
+                ],
+                defaultStyle: {
+                    bgcolor: 0x00ff00
+                },
+                callback: this.onFeedbackCuelistState.bind(this),
+            },
+            [CuelistFeedbacks.IsCurrentCue]: {
+                type: "boolean",
+                name: "Cuelist: Previous/Current/Next cue",
+                options: [
+                    this.repo.generateIdOpion("Cuelist ID or name"),
+                    {
+                        id: "cue_index",
+                        label: "Cue index (0 based)",
+                        tooltip: "Index of cue (0 based position of cue in cuelist), NOT cue number",
+                        type: "number",
+                        min: 0,
+                        max: 4294967295,
+                        default: 0,
+                    },
+                    {
+                        id: "cue_state",
+                        label: "Cue is ...",
+                        type: "dropdown",
+                        choices: [
+                            { id: "previous", label: "...previous" },
+                            { id: "current", label: "...current" },
+                            { id: "next", label: "...next" },
+                        ],
+                        default: "current"
+                    }
+                ],
+                defaultStyle: {
+                    bgcolor: 0xff0000
+                },
+                callback: this.onFeedbackCurrentCue.bind(this)
+            },
+            [CuelistFeedbacks.CueProgress]: {
+                type: "boolean",
+                name: "Cuelist: Cue progress reached",
+                description: "Check if a cue has reached a certain point in its progress. Adding this feedback will subscribe to the progress of the selected cuelist and add variables for its progress",
+                options: [
+                    this.repo.generateIdOpion("Cuelist ID or name"),
+                    {
+                        id: "cue_index",
+                        label: "Cue index (0 based)",
+                        tooltip: "Index of cue (0 based position of cue in cuelist), NOT cue number",
+                        type: "number",
+                        min: 0,
+                        max: 4294967295,
+                        default: 0,
+                    },
+                    {
+                        id: "cue_progress_state",
+                        label: "Cue state",
+                        tooltip: "Feedback is triggered, when this cue state is reaced with the specified value below",
+                        type: "dropdown",
+                        choices: [
+                            { id: ESceneState.None, label: "[ANY]" },
+                            { id: ESceneState.Preparing, label: "Preparing" },
+                            { id: ESceneState.Prepared, label: "Prepared" },
+                            { id: ESceneState.Waiting, label: "Waiting" },
+                            { id: ESceneState.Fading, label: "Fading" },
+                            { id: ESceneState.Playing, label: "Playing" },
+                            { id: ESceneState.Played, label: "Played" },
+                            { id: ESceneState.Stopping, label: "Stopping" },
+                            { id: ESceneState.Stopped, label: "Stopped" },
+                        ],
+                        default: ESceneState.Playing
+                    },
+                    {
+                        id: "cue_progress",
+                        label: "Cue progress",
+                        tooltip: "Feedback is triggered, when the cue progress (progres bar shown in progress column in GUI) compares to this value (0 to 1) with the specified operator in the state above. -1 for ANY progress.",
+                        type: "number",
+                        min: -1,
+                        max: 4294967295,
+                        default: -1,
+                    },
+                    {
+                        id: "cue_progress_compare",
+                        label: "If progress is ...",
+                        tooltip: "The cue progress value must be ... in comparison to the specified value",
+                        type: "dropdown",
+                        choices: [
+                            { id: 0, label: "equal to" },
+                            { id: 1, label: "greater than" },
+                            { id: -1, label: "less than" },
+                        ],
+                        default: 0
+                    },
+                ],
+                defaultStyle: {
+                    bgcolor: 0x0000ff
+                },
+                callback: this.onFeedbackCueProgress.bind(this),
+                subscribe: this.onFeedbackCueProgressSubscribe.bind(this),
+                unsubscribe: this.onFeedbackCueProgressUnsubscribe.bind(this),
+            }
+        };
+        return feedbacks;
+    }
+    generatePresets(): CompanionPresetDefinitions {
+        return {}
+    }
+
+    private setVariables(variables: VariableWithValue[]) {
+        this.instance.setVariableValues(Object.fromEntries(variables.map(v => [v.variableId, v.value])));
+    }
+
+    private generateVariablesCuelistProperties(cuelistId: string): VariableWithValue[] {
+        const list = this.repo.getSingle(cuelistId);
+        if (!list) {
+            return [];
+        }
+        const currCue = list.cues[list.index];
+        const nextCue = list.cues[list.nextIndex];
+        const playMode = Object.entries(ESceneListPlayMode).find(([_, modeInt]) => modeInt == list.playMode);
+        return [
+            { variableId: `cuelist_${list.id}_name`, name: `Cuelist ${list.name} name`, value: list.name },
+            { variableId: `cuelist_${list.id}_currentCue`, name: `Cuelist ${list.name} current cue number`, value: currCue?.cueNumber?.number.join(".") ?? "" },
+            { variableId: `cuelist_${list.id}_nextCue`, name: `Cuelist ${list.name} next cue number`, value: nextCue?.cueNumber?.number.join(".") ?? "" },
+            { variableId: `cuelist_${list.id}_intensity`, name: `Cuelist ${list.name} intensity`, value: list.intensity },
+            { variableId: `cuelist_${list.id}_fadeFactor`, name: `Cuelist ${list.name} fade factor`, value: list.fadeFactor },
+            { variableId: `cuelist_${list.id}_speedFactor`, name: `Cuelist ${list.name} speed factor`, value: list.speedFactor },
+            { variableId: `cuelist_${list.id}_playMode`, name: `Cuelist ${list.name} play mode`, value: playMode ? playMode[0] : "" },
+            ...list.cues.flatMap(cue => {
+                return [
+                    { variableId: `cuelist_${list.id}_cue_${cue.cueIndex}_number`, name: `Cuelist ${list.name} cue ${cue.cueNumber?.number.join(".")} number`, value: cue.cueNumber?.number.join(".") ?? "" },
+                    { variableId: `cuelist_${list.id}_cue_${cue.cueIndex}_name`, name: `Cuelist ${list.name} cue ${cue.cueNumber?.number.join(".")} name`, value: cue.name ?? "" },
+                ];
+            })
+        ];
+    }
+
+    private generateVariablesCueProgress(cuelistId: string): VariableWithValue[] {
+        const list = this.repo.getSingle(cuelistId);
+        if (!list) {
+            return [];
+        }
+        const cuesOfList = this.cueProgressPerCuelist.get(cuelistId);
+        return list.cues.flatMap((cue, i) => {
+            const cueProgress = cuesOfList?.get(i);
+            const statesStr = cueProgress
+                ? Object.entries(ESceneState)
+                    .filter(([_, stateNum]) => typeof stateNum === "number" && (cueProgress.cueState & stateNum) != 0)
+                    .map(([stateStr, _]) => stateStr).join("|")
+                : ""
+            return [
+                { variableId: `cuelist_${list.id}_cue_${i}_state`, name: `Cuelist ${list.name} cue ${cue.cueNumber?.number.join(".")} state (numeric flag)`, value: cueProgress?.cueState ?? ESceneState.None },
+                { variableId: `cuelist_${list.id}_cue_${i}_stateStr`, name: `Cuelist ${list.name} cue ${cue.cueNumber?.number.join(".")} state (string)`, value: statesStr },
+                { variableId: `cuelist_${list.id}_cue_${i}_progress`, name: `Cuelist ${list.name} cue ${cue.cueNumber?.number.join(".")} progress`, value: cueProgress?.progress ?? -1 },
+                { variableId: `cuelist_${list.id}_cue_${i}_msToWait`, name: `Cuelist ${list.name} cue ${cue.cueNumber?.number.join(".")} time in ms until cue is triggered`, value: cueProgress?.msToWait ?? -1 },
+                { variableId: `cuelist_${list.id}_cue_${i}_fadeTimeLeft`, name: `Cuelist ${list.name} cue ${cue.cueNumber?.number.join(".")} time left in fade (only on incoming) in ms`, value: cueProgress?.fadeTimeLeft ?? -1 },
+                { variableId: `cuelist_${list.id}_cue_${i}_delayTimeLeft`, name: `Cuelist ${list.name} cue ${cue.cueNumber?.number.join(".")} time left in pre delay in ms`, value: cueProgress?.delayTimeLeft ?? -1 },
+                { variableId: `cuelist_${list.id}_cue_${i}_durationTimeLeft`, name: `Cuelist ${list.name} cue ${cue.cueNumber?.number.join(".")} state`, value: cueProgress?.durationTimeLeft ?? -1 },
+            ]
+        })
+    }
+
+    generateVariables(): CompanionVariableDefinition[] {
+        return [
+            ...this.repo.getIds().flatMap(id => this.generateVariablesCuelistProperties(id)),
+            ...[...this.progressFeedbacks.entries()]
+                .filter(([_, feedbacks]) => feedbacks.size > 0)
+                .flatMap(([cuelistId, _]) => this.generateVariablesCueProgress(cuelistId))
+        ]
+    }
+
+    close(): void {
+        if (this.pollInterval != null) {
+            clearInterval(this.pollInterval);
+            this.pollInterval = null;
+        }
+        if (this.progressStream != null) {
+            this.progressStream.end();
+        }
+        this.grpcclient.close();
+    }
+
+    private async onActionSetIntensity(event: CompanionActionEvent) {
+        try {
+            const intensity = event.options?.intensity as number;
+            if (typeof intensity !== "number") {
+                throw new Error("To set cuelist intensity, cuelist id and intensity must be set");
+            }
+            const list = this.repo.checkAndGetIdOption(event.options);
+
+            const actionRes = await new Promise<ConfirmedResponse>((resolve, reject) =>
+                this.grpcclient.setCuelistValue(
+                    SetCuelistValueRequest.create({
+                        requestId: this.instance.getRequestId(),
+                        cuelistId: list.id,
+                        intensity: intensity / 100
+                    }),
+                    this.metadata,
+                    (err, res) => err != null ? reject(err) : resolve(res)
+                ));
+
+            if (!actionRes.ok) {
+                this.instance.log("error", "While setting cuelist intensity: " + JSON.stringify(actionRes.message))
+            }
+        } catch (err) {
+            this.instance.log("warn", (err as Error)?.message);
+        }
+    }
+
+    private async onActionCuelistAction(event: CompanionActionEvent) {
+        try {
+            const actionStr = event.options?.actionType as keyof typeof CuelistActionRequest_EAction | undefined;
+            if (typeof actionStr !== "string") {
+                throw new Error("To call cuelist action, action type must be set");
+            }
+            const action = CuelistActionRequest_EAction[actionStr];
+            if (!action) {
+                throw new Error(`Cuelist action ${actionStr} does not exist.`);
+            }
+            const list = this.repo.checkAndGetIdOption(event.options)
+
+            const actionRes = await new Promise<ConfirmedResponse>((resolve, reject) =>
+                this.grpcclient.cuelistAction(
+                    CuelistActionRequest.create({
+                        requestId: this.instance.getRequestId(),
+                        cuelistId: list.id,
+                        action: action,
+                    }),
+                    this.metadata,
+                    (err, res) => err != null ? reject(err) : resolve(res)
+                ));
+
+            if (!actionRes.ok) {
+                this.instance.log("error", "While running cuelist action: " + JSON.stringify(actionRes.message))
+            }
+        } catch (err) {
+            this.instance.log("warn", (err as Error)?.message);
+        }
+    }
+
+    private onFeedbackCuelistState(feedback: CompanionFeedbackInfo, _: CompanionCommonCallbackContext): boolean {
+        try {
+            const stateStr = feedback.options.state as keyof typeof ESceneListState;
+            if (typeof stateStr !== "string") {
+                throw new Error("For feedback, cuelist state must be set");
+            }
+            const state = ESceneListState[stateStr];
+            if (typeof state !== typeof ESceneListState.STOPPED) {
+                throw new Error(`Unknown cuelist state ${stateStr}`);
+            }
+            const list = this.repo.checkAndGetIdOption(feedback.options);
+            return list.state == state;
+        } catch (err) {
+            this.instance.log("warn", (err as Error)?.message);
+            return false;
+        }
+    }
+
+    private onFeedbackCurrentCue(feedback: CompanionFeedbackInfo, _: CompanionCommonCallbackContext): boolean {
+        try {
+            const cueState = feedback.options.cue_state as string;
+            if (!["previous", "current", "next"].includes(cueState)) {
+                throw new Error("For current cue feedback, must select cue state.");
+            }
+            const cueIndex = feedback.options.cue_index as number;
+            if (typeof cueIndex !== "number") {
+                throw new Error(`Cue index to check must be number`);
+            }
+            const list = this.repo.checkAndGetIdOption(feedback.options);
+            switch (cueState) {
+                case "previous":
+                    return list.previousIndex == cueIndex;
+                case "current":
+                    return list.index == cueIndex;
+                case "next":
+                    return list.nextIndex == cueIndex;
+            }
+            return false;
+        } catch (err) {
+            this.instance.log("warn", (err as Error)?.message);
+            return false;
+        }
+    }
+
+    private onFeedbackCueProgressCheckOptions(options: CompanionOptionValues): { cueProgressState: number, cueIndex: number, cueProgress: number, comparisonOperator: number } {
+        // Check options:
+        const cueProgressState = options.cue_progress_state as number;
+        if (!Object.values(ESceneState).includes(cueProgressState)) {
+            throw new Error("For cue progress feedback, must select valid cue progress state.");
+        }
+        const cueIndex = options.cue_index as number;
+        if (typeof cueIndex !== "number") {
+            throw new Error(`Cue index to check must be number`);
+        }
+        const cueProgress = options.cue_progress as number;
+        if (typeof cueProgress !== "number" || !isFinite(cueProgress)) {
+            throw new Error(`Cue progress to check must be number`);
+        }
+        const comparisonOperator = options.cue_progress_compare as number;
+        if (typeof comparisonOperator !== "number" || !isFinite(comparisonOperator)) {
+            throw new Error(`Not a valid comparison operator`);
+        }
+        return { cueProgressState, cueIndex, cueProgress, comparisonOperator };
+    }
+
+    private onFeedbackCueProgress(feedback: CompanionFeedbackInfo, _: CompanionCommonCallbackContext): boolean {
+        try {
+            const { cueProgressState, cueIndex, cueProgress, comparisonOperator } = this.onFeedbackCueProgressCheckOptions(feedback.options);
+            const list = this.repo.checkAndGetIdOption(feedback.options);
+
+            const listProgress = this.cueProgressPerCuelist.get(list.id);
+            if (!listProgress) {
+                return false;
+            }
+            const cueProgressMsg = listProgress.get(cueIndex);
+            if (!cueProgressMsg) {
+                return false;
+            }
+            if (cueProgressState != ESceneState.None && (cueProgressMsg.cueState & cueProgressState) == 0) {
+                return false;
+            }
+            if (cueProgress >= 0) {
+                if (comparisonOperator == 0) {
+                    if (Math.abs(cueProgressMsg.progress - cueProgress) > 0.01 /*1% tolerance because of float impercision*/) {
+                        return false;
+                    }
+                } else if ((cueProgressMsg.progress - cueProgress) * comparisonOperator <= 0) {
+                    return false;
+                }
+            }
+            return true;
+        } catch (err) {
+            // don't log (option) errors as they are already logged in subscribe
+            return false;
+        }
+    }
+
+    private async onFeedbackCueProgressSubscribe(feedback: CompanionFeedbackInfo, _: CompanionCommonCallbackContext) {
+        try {
+            const list = this.repo.checkAndGetIdOption(feedback.options);
+            const subscribedFeedbacks = this.progressFeedbacks.get(list.id) ?? new Set();
+            if (!this.progressFeedbacks.has(list.id)) {
+                this.progressFeedbacks.set(list.id, subscribedFeedbacks);
+            }
+            const isNewCuelist = subscribedFeedbacks.size == 0;
+            this.instance.log("debug", `Feedback ${feedback.id} subscribed to ${list.id} progress`);
+            subscribedFeedbacks.add(feedback.id);
+            if (isNewCuelist) {
+                await new Promise<void>((resolve, reject) =>
+                    this.progressStream?.write(CuelistProgressStateChangeRequest.create({
+                        cuelistIds: [...this.progressFeedbacks.entries()].filter(([_, feedbacks]) => feedbacks.size > 0).map(([cuelistId, _]) => cuelistId)
+                    }), (err: any) => err ? reject(err) : resolve())
+                );
+                this.updateVariables();
+                this.setVariables(this.generateVariablesCueProgress(list.id));
+            }
+
+            this.onFeedbackCueProgressCheckOptions(feedback.options);
+        } catch (err) {
+            this.instance.log("warn", (err as Error)?.message);
+        }
+    }
+
+    private async onFeedbackCueProgressUnsubscribe(feedback: CompanionFeedbackInfo, _: CompanionCommonCallbackContext) {
+        try {
+            const list = this.repo.checkAndGetIdOption(feedback.options);
+            const subscribedFeedbacks = this.progressFeedbacks.get(list.id);
+            this.instance.log("debug", `Feedback ${feedback.id} unsubscribed from ${list.id} progress`);
+            if (!subscribedFeedbacks) {
+                return;
+            }
+            subscribedFeedbacks.delete(feedback.id);
+            if (subscribedFeedbacks.size == 0) {
+                await new Promise<void>((resolve, reject) =>
+                    this.progressStream?.write(CuelistProgressStateChangeRequest.create({
+                        cuelistIds: [...this.progressFeedbacks.entries()].filter(([_, feedbacks]) => feedbacks.size > 0).map(([cuelistId, _]) => cuelistId)
+                    }), (err: any) => err ? reject(err) : resolve())
+                );
+                this.updateVariables();
+            }
+        } catch (err) {
+            this.instance.log("warn", (err as Error)?.message);
+        }
+    }
+}

--- a/src/grpc/grpcclient.ts
+++ b/src/grpc/grpcclient.ts
@@ -177,7 +177,7 @@ export class GRPCClient {
                 );
                 const stream = this.connectedClient.ping(this.metadata);
                 stream.on("error", (err) => {
-                    instance.log("error", err.message);
+                    instance.log("error", "In Ping stream: " + err.message);
                     onError();
                 });
                 stream.on("data", (data: PingPong) => {
@@ -209,7 +209,7 @@ export class GRPCClient {
                     this.metadata,
                     (error, _) => {
                         if (error) {
-                            instance.log("error", error.message);
+                            instance.log("error", "While binding user: " + error.message);
                             onError();
                             return;
                         }
@@ -234,47 +234,22 @@ export class GRPCClient {
                                 )
                             );
 
-                            const actions: CompanionActionDefinitions = {};
-                            for (const a of this.clients.map((c) =>
-                                c.generateActions()
-                            )) {
-                                for (const key in a) {
-                                    actions[key] = a[key];
-                                }
-                            }
-                            this.instance.setActionDefinitions(actions);
-
-                            const feedbacks: CompanionFeedbackDefinitions = {};
-                            for (const f of this.clients.map((c) =>
-                                c.generateFeedbacks()
-                            )) {
-                                for (const key in f) {
-                                    feedbacks[key] = f[key];
-                                }
-                            }
-
-                            this.instance.log(
-                                "debug",
-                                `Set feedbacks: ${JSON.stringify(feedbacks)}`
-                            );
-
-                            this.instance.setFeedbackDefinitions(feedbacks);
-
-                            this.instance.setVariableDefinitions(
-                                this.clients
-                                    .map((c) => c.generateVariables())
-                                    .flat()
-                            );
+                            this.updateActions();
+                            this.updateFeedbacks();
 
                             this.clients.forEach((client) => {
-                                client.startClient(() => {
-                                    this.updatePresets();
-                                });
+                                client.startClient(
+                                    this.updatePresets.bind(this),
+                                    this.updateActions.bind(this),
+                                    this.updateFeedbacks.bind(this),
+                                    this.updateVariables.bind(this),
+                                );
                             });
-                        } catch {
+                        } catch (err) {
                             instance.log(
                                 "error",
-                                "Something died while retrieving changes!"
+                                "Something died while retrieving changes: " +
+                                ((err as Error)?.message ? (err as Error).message : err)
                             );
                             onError();
                         }
@@ -295,6 +270,44 @@ export class GRPCClient {
         this.instance.setPresetDefinitions(presets);
     }
 
+    updateActions() {
+        const actions: CompanionActionDefinitions = {};
+        for (const a of this.clients.map((c) =>
+            c.generateActions()
+        )) {
+            for (const key in a) {
+                actions[key] = a[key];
+            }
+        }
+        this.instance.setActionDefinitions(actions);
+    }
+
+    updateFeedbacks() {
+        const feedbacks: CompanionFeedbackDefinitions = {};
+        for (const f of this.clients.map((c) =>
+            c.generateFeedbacks()
+        )) {
+            for (const key in f) {
+                feedbacks[key] = f[key];
+            }
+        }
+
+        this.instance.log(
+            "debug",
+            `Set feedbacks: ${JSON.stringify(feedbacks)}`
+        );
+
+        this.instance.setFeedbackDefinitions(feedbacks);
+    }
+
+    updateVariables() {
+        this.instance.setVariableDefinitions(
+            this.clients
+                .map((c) => c.generateVariables())
+                .flat()
+        );
+    }
+
     public getMetadata(): GRPC.Metadata | undefined {
         return this.metadata;
     }
@@ -312,7 +325,7 @@ export class GRPCClient {
             }),
             (error, response) => {
                 if (error) {
-                    instance.log("error", error.message);
+                    instance.log("error", "While logging off: " + error.message);
                     return;
                 }
                 instance.log("debug", response.bye);

--- a/src/grpc/grpcclient.ts
+++ b/src/grpc/grpcclient.ts
@@ -32,6 +32,7 @@ import {
 import { UserContextRequest } from "@deluxequadrat/dmxc-grpc-client/dist/index.LumosProtobuf.User";
 import { UserClientClient } from "@deluxequadrat/dmxc-grpc-client/dist/index.LumosProtobufClient";
 import { IDMXCClient } from "./idmxcclient";
+import { CuelistClient } from "./cuelistclient";
 
 export class GRPCClient {
     private umbraClient: ClientServiceClient;
@@ -228,6 +229,13 @@ export class GRPCClient {
                             );
                             this.clients.push(
                                 new MacroClient(
+                                    this.endpoint,
+                                    this.metadata,
+                                    instance
+                                )
+                            );
+                            this.clients.push(
+                                new CuelistClient(
                                     this.endpoint,
                                     this.metadata,
                                     instance

--- a/src/grpc/idmxcclient.ts
+++ b/src/grpc/idmxcclient.ts
@@ -9,7 +9,7 @@ import { Client } from "@grpc/grpc-js";
 export interface IDMXCClient {
     grpcclient: Client;
 
-    startClient(updatePresets: () => void): void;
+    startClient(updatePresets: () => void, updateActions: () => void, updateFeedbacks: () => void, updateVariables: () => void): void;
 
     generateActions(): CompanionActionDefinitions;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,7 @@ import { DMXCModuleInstance } from "./main";
 import dgram from "dgram";
 import { GRPCClient } from "./grpc/grpcclient";
 import { UmbraUdpBroadcast } from "@deluxequadrat/dmxc-grpc-client/dist/index.LumosProtobuf";
+import { CompanionInputFieldDropdown, CompanionInputFieldNumber, CompanionInputFieldTextInput, CompanionOptionValues } from "@companion-module/base";
 
 export function hashPasswordDMXC(password: string): string {
     let hash = createHash("sha256");
@@ -43,7 +44,7 @@ export function startDiscovery(
             umbraClient = new GRPCClient(
                 rinfo.address,
                 umbraUdpBroadcast.umbraServer?.clientInfo?.umbraPort ??
-                    config.port,
+                config.port,
                 config.devicename,
                 instance
             );
@@ -78,4 +79,91 @@ export function startDiscovery(
     });
 
     return client;
+}
+
+enum NumberVariableFieldType {
+    Number = "number",
+    TextVariables = "textinput",
+}
+
+/**
+ * Generates companion input fields to allow the user to enter a number or specify it using a (variable) expression
+ * 
+ * @param label The label for the input field
+ * @param min Minimum value the entered number may be (inclusive)
+ * @param max Maximum value the entered number may be (inclusive)
+ * @param defaultVal The value that should be preselected in the number input field
+ * @param id (Optional) specify the id prefix used for the fields to allow fo multiple instances
+ * @returns 3 Companion input fields (choice between number/text, conditional number input, conditional text/expression input)
+ */
+export function generateNumberOrVariableField(label: string, min: number, max: number, defaultVal: number, id: string = "numeric"): (CompanionInputFieldDropdown | CompanionInputFieldNumber | CompanionInputFieldTextInput)[] {
+    return [
+        {
+            type: "dropdown",
+            label: `Type of ${label} field`,
+            id: `${id}_type`,
+            default: NumberVariableFieldType.Number,
+            choices: [
+                { id: NumberVariableFieldType.Number, label: "Number input" },
+                { id: NumberVariableFieldType.TextVariables, label: "Text/Variables" },
+            ],
+        },
+        {
+            id: `${id}_number`,
+            type: `number`,
+            label,
+            min: min,
+            max: max,
+            default: defaultVal,
+            isVisibleExpression: `$(options:${id}_type) == "${NumberVariableFieldType.Number}"`,
+        },
+        {
+            id: `${id}_text`,
+            type: `textinput`,
+            label: label + " (with variables)",
+            default: "",
+            isVisibleExpression: `$(options:${id}_type) == "${NumberVariableFieldType.TextVariables}"`,
+            useVariables: {
+                local: true,
+            },
+        },
+    ]
+}
+
+/**
+ * Retrieves the numeric value entered in the fields created with `generateNumberOrVariableField`
+ * 
+ * @param min Minimum value the entered number may be (inclusive)
+ * @param max Maximum value the entered number may be (inclusive)
+ * @param options The (full, unmodified) `options` object returned in the event (e.g. in an action) by companion
+ * @param parseVariablesInString The `parseVariablesInString` in the context (second param) passed to events (e.g. actions)
+ * @param id (Optional) id prefix used when reating the fields (allows multiple instances)
+ * @returns Promise resolving to the entered number
+ * @throws Rejects promise if user input isn't a valid finite number within the specified range
+ */
+export async function checkAndGetNumberOrVariable(min: number, max: number, options: CompanionOptionValues, parseVariablesInString: (text: string) => Promise<string>, id: string = "numeric"): Promise<number> {
+    const field_type = options[`${id}_type`] as string;
+    if (typeof field_type !== "string") {
+        throw new Error("A valid way to input a number must be selected: " + JSON.stringify(options));
+    }
+    let num: number;
+    switch (field_type) {
+        case NumberVariableFieldType.Number:
+            num = options[`${id}_number`] as number;
+            break;
+        case NumberVariableFieldType.TextVariables:
+            const res = await parseVariablesInString(options[`${id}_text`] as string);
+            console.log("Entered str value:", options[`${id}_text`], res);
+            num = parseFloat(res);
+            break;
+        default:
+            throw new Error("Unknown way to input a number");
+    }
+    if (typeof num !== "number" || !isFinite(num)) {
+        throw new Error("Make sure you enter a valid, finite number.");
+    }
+    if (num < min || num > max) {
+        throw new Error(`Entered number ${num} was outside valid range of [${min},${max}]`);
+    }
+    return num;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,26 +6,26 @@ __metadata:
   cacheKey: 10c0
 
 "@bufbuild/protobuf@npm:^2.5.1":
-  version: 2.5.1
-  resolution: "@bufbuild/protobuf@npm:2.5.1"
-  checksum: 10c0/dd3044160c6ed27db3d26999b6cf7c47178cd1d31abf156ca5902d3a3670b811a8018d3d4a3154dbc30d6a9f29402d16189e53a51dd437a8c59e6e56fc079b74
+  version: 2.7.0
+  resolution: "@bufbuild/protobuf@npm:2.7.0"
+  checksum: 10c0/9ae9b9ef7f8fd5cc0fdf8c45650c9cbd4324b61ca289feb2e7a28dabda755f025241ce58a88ae269821fd719302a6fc6709bcdb2175b7311ba4feb8af73ed560
   languageName: node
   linkType: hard
 
-"@companion-module/base@npm:~1.11.0":
-  version: 1.11.3
-  resolution: "@companion-module/base@npm:1.11.3"
+"@companion-module/base@npm:~1.12.0":
+  version: 1.12.1
+  resolution: "@companion-module/base@npm:1.12.1"
   dependencies:
     ajv: "npm:^8.17.1"
     colord: "npm:^2.9.3"
     ejson: "npm:^2.2.3"
     eventemitter3: "npm:^5.0.1"
     mimic-fn: "npm:^3.1.0"
-    nanoid: "npm:^3.3.8"
+    nanoid: "npm:^3.3.11"
     p-queue: "npm:^6.6.2"
     p-timeout: "npm:^4.1.0"
     tslib: "npm:^2.8.1"
-  checksum: 10c0/19acbc544de97ed8f02abf03e1d657085e51f0e92363456a84bdc1975723ba1bdfc0e943ff17444cb4e6a2b588abb794a9c5b48efb4d784be32784362e7c4efd
+  checksum: 10c0/11e67f87ba7f1dff830247882638da7cbc07d70ae47c606f43876ed183657b81ac7264e771e79735486d93c9845b0f28cfc8283d5d24b1b9eeb13a8e5b82db9d
   languageName: node
   linkType: hard
 
@@ -99,30 +99,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/config-array@npm:^0.20.0":
-  version: 0.20.0
-  resolution: "@eslint/config-array@npm:0.20.0"
+"@eslint/config-array@npm:^0.21.0":
+  version: 0.21.0
+  resolution: "@eslint/config-array@npm:0.21.0"
   dependencies:
     "@eslint/object-schema": "npm:^2.1.6"
     debug: "npm:^4.3.1"
     minimatch: "npm:^3.1.2"
-  checksum: 10c0/94bc5d0abb96dc5295ff559925242ff75a54eacfb3576677e95917e42f7175e1c4b87bf039aa2a872f949b4852ad9724bf2f7529aaea6b98f28bb3fca7f1d659
+  checksum: 10c0/0ea801139166c4aa56465b309af512ef9b2d3c68f9198751bbc3e21894fe70f25fbf26e1b0e9fffff41857bc21bfddeee58649ae6d79aadcd747db0c5dca771f
   languageName: node
   linkType: hard
 
-"@eslint/config-helpers@npm:^0.2.1":
-  version: 0.2.2
-  resolution: "@eslint/config-helpers@npm:0.2.2"
-  checksum: 10c0/98f7cefe484bb754674585d9e73cf1414a3ab4fd0783c385465288d13eb1a8d8e7d7b0611259fc52b76b396c11a13517be5036d1f48eeb877f6f0a6b9c4f03ad
+"@eslint/config-helpers@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@eslint/config-helpers@npm:0.3.1"
+  checksum: 10c0/f6c5b3a0b76a0d7d84cc93e310c259e6c3e0792ddd0a62c5fc0027796ffae44183432cb74b2c2b1162801ee1b1b34a6beb5d90a151632b4df7349f994146a856
   languageName: node
   linkType: hard
 
-"@eslint/core@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@eslint/core@npm:0.14.0"
+"@eslint/core@npm:^0.15.2":
+  version: 0.15.2
+  resolution: "@eslint/core@npm:0.15.2"
   dependencies:
     "@types/json-schema": "npm:^7.0.15"
-  checksum: 10c0/259f279445834ba2d2cbcc18e9d43202a4011fde22f29d5fb802181d66e0f6f0bd1f6b4b4b46663451f545d35134498231bd5e656e18d9034a457824b92b7741
+  checksum: 10c0/c17a6dc4f5a6006ecb60165cc38bcd21fefb4a10c7a2578a0cfe5813bbd442531a87ed741da5adab5eb678e8e693fda2e2b14555b035355537e32bcec367ea17
   languageName: node
   linkType: hard
 
@@ -143,10 +143,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.27.0, @eslint/js@npm:^9.19.0":
-  version: 9.27.0
-  resolution: "@eslint/js@npm:9.27.0"
-  checksum: 10c0/79b219ceda79182732954b52f7a494f49995a9a6419c7ae0316866e324d3706afeb857e1306bb6f35a4caaf176a5174d00228fc93d36781a570d32c587736564
+"@eslint/js@npm:9.33.0, @eslint/js@npm:^9.19.0":
+  version: 9.33.0
+  resolution: "@eslint/js@npm:9.33.0"
+  checksum: 10c0/4c42c9abde76a183b8e47205fd6c3116b058f82f07b6ad4de40de56cdb30a36e9ecd40efbea1b63a84d08c206aadbb0aa39a890197e1ad6455a8e542df98f186
   languageName: node
   linkType: hard
 
@@ -157,13 +157,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/plugin-kit@npm:^0.3.1":
-  version: 0.3.1
-  resolution: "@eslint/plugin-kit@npm:0.3.1"
+"@eslint/plugin-kit@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "@eslint/plugin-kit@npm:0.3.5"
   dependencies:
-    "@eslint/core": "npm:^0.14.0"
+    "@eslint/core": "npm:^0.15.2"
     levn: "npm:^0.4.1"
-  checksum: 10c0/a75f0b5d38430318a551b83e27bee570747eb50beeb76b03f64b0e78c2c27ef3d284cfda3443134df028db3251719bc0850c105f778122f6ad762d5270ec8063
+  checksum: 10c0/c178c1b58c574200c0fd125af3e4bc775daba7ce434ba6d1eeaf9bcb64b2e9fea75efabffb3ed3ab28858e55a016a5efa95f509994ee4341b341199ca630b89e
   languageName: node
   linkType: hard
 
@@ -239,13 +239,12 @@ __metadata:
   linkType: hard
 
 "@jridgewell/gen-mapping@npm:^0.3.5":
-  version: 0.3.8
-  resolution: "@jridgewell/gen-mapping@npm:0.3.8"
+  version: 0.3.13
+  resolution: "@jridgewell/gen-mapping@npm:0.3.13"
   dependencies:
-    "@jridgewell/set-array": "npm:^1.2.1"
-    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
+    "@jridgewell/sourcemap-codec": "npm:^1.5.0"
     "@jridgewell/trace-mapping": "npm:^0.3.24"
-  checksum: 10c0/c668feaf86c501d7c804904a61c23c67447b2137b813b9ce03eca82cb9d65ac7006d766c218685d76e3d72828279b6ee26c347aa1119dab23fbaf36aed51585a
+  checksum: 10c0/9a7d65fb13bd9aec1fbab74cda08496839b7e2ceb31f5ab922b323e94d7c481ce0fc4fd7e12e2610915ed8af51178bdc61e168e92a8c8b8303b030b03489b13b
   languageName: node
   linkType: hard
 
@@ -256,37 +255,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/set-array@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "@jridgewell/set-array@npm:1.2.1"
-  checksum: 10c0/2a5aa7b4b5c3464c895c802d8ae3f3d2b92fcbe84ad12f8d0bfbb1f5ad006717e7577ee1fd2eac00c088abe486c7adb27976f45d2941ff6b0b92b2c3302c60f4
-  languageName: node
-  linkType: hard
-
 "@jridgewell/source-map@npm:^0.3.3":
-  version: 0.3.6
-  resolution: "@jridgewell/source-map@npm:0.3.6"
+  version: 0.3.11
+  resolution: "@jridgewell/source-map@npm:0.3.11"
   dependencies:
     "@jridgewell/gen-mapping": "npm:^0.3.5"
     "@jridgewell/trace-mapping": "npm:^0.3.25"
-  checksum: 10c0/6a4ecc713ed246ff8e5bdcc1ef7c49aaa93f7463d948ba5054dda18b02dcc6a055e2828c577bcceee058f302ce1fc95595713d44f5c45e43d459f88d267f2f04
+  checksum: 10c0/50a4fdafe0b8f655cb2877e59fe81320272eaa4ccdbe6b9b87f10614b2220399ae3e05c16137a59db1f189523b42c7f88bd097ee991dbd7bc0e01113c583e844
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14":
-  version: 1.5.0
-  resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
-  checksum: 10c0/2eb864f276eb1096c3c11da3e9bb518f6d9fc0023c78344cdc037abadc725172c70314bdb360f2d4b7bffec7f5d657ce006816bc5d4ecb35e61b66132db00c18
+"@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0":
+  version: 1.5.5
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
+  checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
   languageName: node
   linkType: hard
 
 "@jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25":
-  version: 0.3.25
-  resolution: "@jridgewell/trace-mapping@npm:0.3.25"
+  version: 0.3.30
+  resolution: "@jridgewell/trace-mapping@npm:0.3.30"
   dependencies:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
-  checksum: 10c0/3d1ce6ebc69df9682a5a8896b414c6537e428a1d68b02fcc8363b04284a8ca0df04d0ee3013132252ab14f2527bc13bea6526a912ecb5658f0e39fd2860b4df4
+  checksum: 10c0/3a1516c10f44613b9ba27c37a02ff8f410893776b2b3dad20a391b51b884dd60f97bbb56936d65d2ff8fe978510a0000266654ab8426bdb9ceb5fb4585b19e23
   languageName: node
   linkType: hard
 
@@ -324,10 +316,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkgr/core@npm:^0.2.4":
-  version: 0.2.4
-  resolution: "@pkgr/core@npm:0.2.4"
-  checksum: 10c0/2528a443bbbef5d4686614e1d73f834f19ccbc975f62b2a64974a6b97bcdf677b9c5e8948e04808ac4f0d853e2f422adfaae2a06e9e9f4f5cf8af76f1adf8dc1
+"@pkgr/core@npm:^0.2.9":
+  version: 0.2.9
+  resolution: "@pkgr/core@npm:0.2.9"
+  checksum: 10c0/ac8e4e8138b1a7a4ac6282873aef7389c352f1f8b577b4850778f5182e4a39a5241facbe48361fec817f56d02b51691b383010843fb08b34a8e8ea3614688fd5
   languageName: node
   linkType: hard
 
@@ -405,8 +397,8 @@ __metadata:
   linkType: hard
 
 "@stylistic/eslint-plugin@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "@stylistic/eslint-plugin@npm:4.4.0"
+  version: 4.4.1
+  resolution: "@stylistic/eslint-plugin@npm:4.4.1"
   dependencies:
     "@typescript-eslint/utils": "npm:^8.32.1"
     eslint-visitor-keys: "npm:^4.2.0"
@@ -415,7 +407,7 @@ __metadata:
     picomatch: "npm:^4.0.2"
   peerDependencies:
     eslint: ">=9.0.0"
-  checksum: 10c0/f255e40d8a9bcbeacc4292ee19709295da7f6e686753beabed8b9d0c5ebbb3aee968bf1bea8369feb83b81bfb3e07339bcbe143e349219d240188cc862133ae3
+  checksum: 10c0/94160bfc172a3934dd35be87887f43f7e3ffe9d1645096860a4e4c61877bb0fb62eb20a90e50ad74767ee794ed10f334f7165952cf9bcbd8bae6b80dc10c0d62
   languageName: node
   linkType: hard
 
@@ -439,10 +431,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:^1.0.6":
-  version: 1.0.7
-  resolution: "@types/estree@npm:1.0.7"
-  checksum: 10c0/be815254316882f7c40847336cd484c3bc1c3e34f710d197160d455dc9d6d050ffbf4c3bc76585dba86f737f020ab20bdb137ebe0e9116b0c86c7c0342221b8c
+"@types/estree@npm:*, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "@types/estree@npm:1.0.8"
+  checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
   languageName: node
   linkType: hard
 
@@ -454,111 +446,114 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*, @types/node@npm:>=13.7.0":
-  version: 22.15.24
-  resolution: "@types/node@npm:22.15.24"
+  version: 24.3.0
+  resolution: "@types/node@npm:24.3.0"
   dependencies:
-    undici-types: "npm:~6.21.0"
-  checksum: 10c0/16c38e98168fa6c3d2f2b6e95f14f80878d969b39093bc5384385a884d73a7fe361c563b36f14bc27536b337f5baad74321f717b31d2c061b9c48074567eb8c6
+    undici-types: "npm:~7.10.0"
+  checksum: 10c0/96bdeca01f690338957c2dcc92cb9f76c262c10398f8d91860865464412b0f9d309c24d9b03d0bdd26dd47fa7ee3f8227893d5c89bc2009d919a525a22512030
   languageName: node
   linkType: hard
 
 "@typescript-eslint/eslint-plugin@npm:^8.33.0":
-  version: 8.33.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.33.0"
+  version: 8.40.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.40.0"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.10.0"
-    "@typescript-eslint/scope-manager": "npm:8.33.0"
-    "@typescript-eslint/type-utils": "npm:8.33.0"
-    "@typescript-eslint/utils": "npm:8.33.0"
-    "@typescript-eslint/visitor-keys": "npm:8.33.0"
+    "@typescript-eslint/scope-manager": "npm:8.40.0"
+    "@typescript-eslint/type-utils": "npm:8.40.0"
+    "@typescript-eslint/utils": "npm:8.40.0"
+    "@typescript-eslint/visitor-keys": "npm:8.40.0"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^7.0.0"
     natural-compare: "npm:^1.4.0"
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
-    "@typescript-eslint/parser": ^8.33.0
+    "@typescript-eslint/parser": ^8.40.0
     eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/fdfbba2134bb8aa8effb3686a9ffe0a5d9916b41ccdf4339976e0205734f802fca2631939f892ccedd20eee104d8cd0e691720728baeeee17c0f40d7bfe4205d
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/dc8889c3255bce6956432f099059179dd13826ba29670f81ba9238ecde46764ee63459eb73a7d88f4f30e1144a2f000d79c9e3f256fa759689d9b3b74d423bda
   languageName: node
   linkType: hard
 
 "@typescript-eslint/parser@npm:^8.33.0":
-  version: 8.33.0
-  resolution: "@typescript-eslint/parser@npm:8.33.0"
+  version: 8.40.0
+  resolution: "@typescript-eslint/parser@npm:8.40.0"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.33.0"
-    "@typescript-eslint/types": "npm:8.33.0"
-    "@typescript-eslint/typescript-estree": "npm:8.33.0"
-    "@typescript-eslint/visitor-keys": "npm:8.33.0"
+    "@typescript-eslint/scope-manager": "npm:8.40.0"
+    "@typescript-eslint/types": "npm:8.40.0"
+    "@typescript-eslint/typescript-estree": "npm:8.40.0"
+    "@typescript-eslint/visitor-keys": "npm:8.40.0"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/3f6aa8476d912a749a4f3e6ae6cbf90a881f1892efb7b3c88f6654fa03e770d8da511d0298615b0eda880b3811e157ed60e47e6a21aa309cbf912e2d5d79d73c
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/43ca9589b8a1f3f4b30a214c0e2254fa0ad43458ef1258b1d62c5aad52710ad11b9315b124cda79163274147b82201a5d76fab7de413e34bfe8e377142b71e98
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.33.0":
-  version: 8.33.0
-  resolution: "@typescript-eslint/project-service@npm:8.33.0"
+"@typescript-eslint/project-service@npm:8.40.0":
+  version: 8.40.0
+  resolution: "@typescript-eslint/project-service@npm:8.40.0"
   dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.33.0"
-    "@typescript-eslint/types": "npm:^8.33.0"
+    "@typescript-eslint/tsconfig-utils": "npm:^8.40.0"
+    "@typescript-eslint/types": "npm:^8.40.0"
     debug: "npm:^4.3.4"
-  checksum: 10c0/a863d9e3be5ffb53c9d57b25b7a35149dae01afd942dd7fc36bd72a4230676ae12d0f37a789cddaf1baf71e3b35f09436bebbd081336e667b4181b48d0afe8f5
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/scope-manager@npm:8.33.0":
-  version: 8.33.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.33.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.33.0"
-    "@typescript-eslint/visitor-keys": "npm:8.33.0"
-  checksum: 10c0/eb259add242ce40642e7272b414c92ae9407d97cb304981f17f0de0846d5c4ab47d41816ef13da3d3976fe0b7a74df291525be27e4fe4f0ab5d35e86d340faa0
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/tsconfig-utils@npm:8.33.0, @typescript-eslint/tsconfig-utils@npm:^8.33.0":
-  version: 8.33.0
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.33.0"
   peerDependencies:
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/6e9a8e73e65b925f908f31e00be4f1b8d7e89f45d97fa703f468115943c297fc2cc6f9daa0c12b9607f39186f033ac244515f11710df7e1df8302c815ed57389
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/23d62e9ada9750136d0251f268bbe1f9784442ef258bb340a2e1e866749d8076730a14749d9a320d94d7c76df2d108caf21fe35e5dc100385f04be846dc979cb
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.33.0":
-  version: 8.33.0
-  resolution: "@typescript-eslint/type-utils@npm:8.33.0"
+"@typescript-eslint/scope-manager@npm:8.40.0":
+  version: 8.40.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.40.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:8.33.0"
-    "@typescript-eslint/utils": "npm:8.33.0"
+    "@typescript-eslint/types": "npm:8.40.0"
+    "@typescript-eslint/visitor-keys": "npm:8.40.0"
+  checksum: 10c0/48af81f9cdcec466994d290561e8d2fa3f6b156a898b71dd0e65633c896543b44729c5353596e84de2ae61bfd20e1398c3309cdfe86714a9663fd5aded4c9cd0
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/tsconfig-utils@npm:8.40.0, @typescript-eslint/tsconfig-utils@npm:^8.40.0":
+  version: 8.40.0
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.40.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/c2366dcd802901d5cd4f59fc4eab7a00ed119aa4591ba59c507fe495d9af4cfca19431a603602ea675e4c861962230d1c2f100896903750cd1fcfc134702a7d0
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/type-utils@npm:8.40.0":
+  version: 8.40.0
+  resolution: "@typescript-eslint/type-utils@npm:8.40.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.40.0"
+    "@typescript-eslint/typescript-estree": "npm:8.40.0"
+    "@typescript-eslint/utils": "npm:8.40.0"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/4a81c654ba17e8a50e48249f781cb91cddb990044affda7315d9b259aabd638232c9a98ff5f4d45ea3b258098060864026b746fce93ad6b4dcde5e492d93c855
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/660b77d801b2538a4ccb65065269ad0e8370d0be985172b5ecb067f3eea22e64aa8af9e981b31bf2a34002339fe3253b09b55d181ce6d8242fc7daa80ac4aaca
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.33.0, @typescript-eslint/types@npm:^8.33.0":
-  version: 8.33.0
-  resolution: "@typescript-eslint/types@npm:8.33.0"
-  checksum: 10c0/348b64eb408719d7711a433fc9716e0c2aab8b3f3676f5a1cc2e00269044132282cf655deb6d0dd9817544116909513de3b709005352d186949d1014fad1a3cb
+"@typescript-eslint/types@npm:8.40.0, @typescript-eslint/types@npm:^8.40.0":
+  version: 8.40.0
+  resolution: "@typescript-eslint/types@npm:8.40.0"
+  checksum: 10c0/225374fff36d59288a5780667a7a1316c75090d5d60b70a8035ac18786120333ccd08dfdf0e05e30d5a82217e44c57b8708b769dd1eed89f12f2ac4d3a769f76
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.33.0":
-  version: 8.33.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.33.0"
+"@typescript-eslint/typescript-estree@npm:8.40.0":
+  version: 8.40.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.40.0"
   dependencies:
-    "@typescript-eslint/project-service": "npm:8.33.0"
-    "@typescript-eslint/tsconfig-utils": "npm:8.33.0"
-    "@typescript-eslint/types": "npm:8.33.0"
-    "@typescript-eslint/visitor-keys": "npm:8.33.0"
+    "@typescript-eslint/project-service": "npm:8.40.0"
+    "@typescript-eslint/tsconfig-utils": "npm:8.40.0"
+    "@typescript-eslint/types": "npm:8.40.0"
+    "@typescript-eslint/visitor-keys": "npm:8.40.0"
     debug: "npm:^4.3.4"
     fast-glob: "npm:^3.3.2"
     is-glob: "npm:^4.0.3"
@@ -566,33 +561,33 @@ __metadata:
     semver: "npm:^7.6.0"
     ts-api-utils: "npm:^2.1.0"
   peerDependencies:
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/677b12b2e5780ffaef508bddbf8712fe2c3413f3d14fd8fd0cfbe22952a81c6642b3cc26984cf27fdfc3dd2457ae5f8aa04437d3b0ae32987a1895f9648ca7b2
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/6c1ffc17947cb36cbd987cf9705f85223ed1cce584b5244840e36a2b8480861f4dfdb0312f96afbc12e7d1ba586005f0d959042baa0a96a1913ac7ace8e8f6d4
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.33.0, @typescript-eslint/utils@npm:^8.32.1":
-  version: 8.33.0
-  resolution: "@typescript-eslint/utils@npm:8.33.0"
+"@typescript-eslint/utils@npm:8.40.0, @typescript-eslint/utils@npm:^8.32.1":
+  version: 8.40.0
+  resolution: "@typescript-eslint/utils@npm:8.40.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.7.0"
-    "@typescript-eslint/scope-manager": "npm:8.33.0"
-    "@typescript-eslint/types": "npm:8.33.0"
-    "@typescript-eslint/typescript-estree": "npm:8.33.0"
+    "@typescript-eslint/scope-manager": "npm:8.40.0"
+    "@typescript-eslint/types": "npm:8.40.0"
+    "@typescript-eslint/typescript-estree": "npm:8.40.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/a0adb9e13d8f8d8f86ae2e905f3305ad60732e760364b291de66a857a551485d37c23e923299078a47f75d3cca643e1f2aefa010a0beb4cb0d08d0507c1038e1
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 10c0/6b3858b8725083fe7db7fb9bcbde930e758a6ba8ddedd1ed27d828fc1cbe04f54b774ef9144602f8eeaafeea9b19b4fd4c46fdad52a10ade99e6b282c7d0df92
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.33.0":
-  version: 8.33.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.33.0"
+"@typescript-eslint/visitor-keys@npm:8.40.0":
+  version: 8.40.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.40.0"
   dependencies:
-    "@typescript-eslint/types": "npm:8.33.0"
-    eslint-visitor-keys: "npm:^4.2.0"
-  checksum: 10c0/41660f241e78314f69d251792f369ef1eeeab3b40fe4ab11b794d402c95bcb82b61d3e91763e7ab9b0f22011a7ac9c8f9dfd91734d61c9f4eaf4f7660555b53b
+    "@typescript-eslint/types": "npm:8.40.0"
+    eslint-visitor-keys: "npm:^4.2.1"
+  checksum: 10c0/592f1c8c2d3da43a7f74f8ead14f05fafc2e4609d5df36811cf92ead5dc94f6f669556a494048e4746cb3774c60bc52a8c83d75369d5e196778d935c70e7d3a1
   languageName: node
   linkType: hard
 
@@ -794,6 +789,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-import-phases@npm:^1.0.3":
+  version: 1.0.4
+  resolution: "acorn-import-phases@npm:1.0.4"
+  peerDependencies:
+    acorn: ^8.14.0
+  checksum: 10c0/338eb46fc1aed5544f628344cb9af189450b401d152ceadbf1f5746901a5d923016cd0e7740d5606062d374fdf6941c29bb515d2bd133c4f4242d5d4cd73a3c7
+  languageName: node
+  linkType: hard
+
 "acorn-jsx@npm:^5.3.2":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
@@ -803,12 +807,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.14.0":
-  version: 8.14.1
-  resolution: "acorn@npm:8.14.1"
+"acorn@npm:^8.14.0, acorn@npm:^8.15.0":
+  version: 8.15.0
+  resolution: "acorn@npm:8.15.0"
   bin:
     acorn: bin/acorn
-  checksum: 10c0/dbd36c1ed1d2fa3550140000371fcf721578095b18777b85a79df231ca093b08edc6858d75d6e48c73e431c174dcf9214edbd7e6fa5911b93bd8abfa54e47123
+  checksum: 10c0/dec73ff59b7d6628a01eebaece7f2bdb8bb62b9b5926dcad0f8931f2b8b79c2be21f6c68ac095592adb5adb15831a3635d9343e6a91d028bbe85d564875ec3ec
   languageName: node
   linkType: hard
 
@@ -899,21 +903,21 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.11
-  resolution: "brace-expansion@npm:1.1.11"
+  version: 1.1.12
+  resolution: "brace-expansion@npm:1.1.12"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/695a56cd058096a7cb71fb09d9d6a7070113c7be516699ed361317aca2ec169f618e28b8af352e02ab4233fb54eb0168460a40dc320bab0034b36ab59aaad668
+  checksum: 10c0/975fecac2bb7758c062c20d0b3b6288c7cc895219ee25f0a64a9de662dbac981ff0b6e89909c3897c1f84fa353113a721923afdec5f8b2350255b097f12b1f73
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "brace-expansion@npm:2.0.1"
+  version: 2.0.2
+  resolution: "brace-expansion@npm:2.0.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/b358f2fe060e2d7a87aa015979ecea07f3c37d4018f8d6deb5bd4c229ad3a0384fe6029bb76cd8be63c81e516ee52d1a0673edbe2023d53a5191732ae3c3e49f
+  checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
   languageName: node
   linkType: hard
 
@@ -927,16 +931,16 @@ __metadata:
   linkType: hard
 
 "browserslist@npm:^4.24.0":
-  version: 4.25.0
-  resolution: "browserslist@npm:4.25.0"
+  version: 4.25.3
+  resolution: "browserslist@npm:4.25.3"
   dependencies:
-    caniuse-lite: "npm:^1.0.30001718"
-    electron-to-chromium: "npm:^1.5.160"
+    caniuse-lite: "npm:^1.0.30001735"
+    electron-to-chromium: "npm:^1.5.204"
     node-releases: "npm:^2.0.19"
     update-browserslist-db: "npm:^1.1.3"
   bin:
     browserslist: cli.js
-  checksum: 10c0/cc16c55b4468b18684a0e1ca303592b38635b1155d6724f172407192737a2f405b8030d87a05813729592793445b3d15e737b0055f901cdecccb29b1e580a1c5
+  checksum: 10c0/cefbbf962b7c0f0d77e952a4b4b37469db7f7f02bc2be7297810ac3cf086660f48daf78d00f7aad8a11b682f88b0ee0022594165ead749e9e4158a0aa49cd161
   languageName: node
   linkType: hard
 
@@ -954,10 +958,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001718":
-  version: 1.0.30001720
-  resolution: "caniuse-lite@npm:1.0.30001720"
-  checksum: 10c0/ba9f963364ec4bfc8359d15d7e2cf365185fa1fddc90b4f534c71befedae9b3dd0cd2583a25ffc168a02d7b61b6c18b59bda0a1828ea2a5250fd3e35c2c049e9
+"caniuse-lite@npm:^1.0.30001735":
+  version: 1.0.30001735
+  resolution: "caniuse-lite@npm:1.0.30001735"
+  checksum: 10c0/1cb74221f16f8835c903770c1cf88fb73a07298b8398396a2b97570136e8f691053ee5840eb589fe34b4ede14ab828c9421d893a67e43c26ef91ab052813cb8c
   languageName: node
   linkType: hard
 
@@ -1092,7 +1096,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "dmxcontrolprojects-dmxcontrol3@workspace:."
   dependencies:
-    "@companion-module/base": "npm:~1.11.0"
+    "@companion-module/base": "npm:~1.12.0"
     "@companion-module/tools": "npm:^2.3.0"
     "@deluxequadrat/dmxc-grpc-client": "npm:^1.0.2"
     "@stylistic/eslint-plugin": "npm:^4.4.0"
@@ -1112,10 +1116,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.5.160":
-  version: 1.5.161
-  resolution: "electron-to-chromium@npm:1.5.161"
-  checksum: 10c0/64e06657b747d889fdacd7ee042f5f2e189d215b6e7b8510d899d1eeb82676f9d4431ee6822cee009195500338f23996b9ae4eec0e4eb4e907e13e2d28489d5b
+"electron-to-chromium@npm:^1.5.204":
+  version: 1.5.207
+  resolution: "electron-to-chromium@npm:1.5.207"
+  checksum: 10c0/33de5f996fcfdb7c7fcedfc76e9e36ed33f2b7a3136b1bbc5eae38f2b0441fbd114843511a46c80aaf21b9586d812fe469ff7f948c5cda0808038c69c4f76298
   languageName: node
   linkType: hard
 
@@ -1126,13 +1130,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.17.1":
-  version: 5.18.1
-  resolution: "enhanced-resolve@npm:5.18.1"
+"enhanced-resolve@npm:^5.17.1, enhanced-resolve@npm:^5.17.3":
+  version: 5.18.3
+  resolution: "enhanced-resolve@npm:5.18.3"
   dependencies:
     graceful-fs: "npm:^4.2.4"
     tapable: "npm:^2.2.0"
-  checksum: 10c0/4cffd9b125225184e2abed9fdf0ed3dbd2224c873b165d0838fd066cde32e0918626cba2f1f4bf6860762f13a7e2364fd89a82b99566be2873d813573ac71846
+  checksum: 10c0/d413c23c2d494e4c1c9c9ac7d60b812083dc6d446699ed495e69c920988af0a3c66bf3f8d0e7a45cb1686c2d4c1df9f4e7352d973f5b56fe63d8d711dd0ccc54
   languageName: node
   linkType: hard
 
@@ -1178,13 +1182,13 @@ __metadata:
   linkType: hard
 
 "eslint-config-prettier@npm:^10.0.1, eslint-config-prettier@npm:^10.1.0":
-  version: 10.1.5
-  resolution: "eslint-config-prettier@npm:10.1.5"
+  version: 10.1.8
+  resolution: "eslint-config-prettier@npm:10.1.8"
   peerDependencies:
     eslint: ">=7.0.0"
   bin:
     eslint-config-prettier: bin/cli.js
-  checksum: 10c0/5486255428e4577e8064b40f27db299faf7312b8e43d7b4bc913a6426e6c0f5950cd519cad81ae24e9aecb4002c502bc665c02e3b52efde57af2debcf27dd6e0
+  checksum: 10c0/e1bcfadc9eccd526c240056b1e59c5cd26544fe59feb85f38f4f1f116caed96aea0b3b87868e68b3099e55caaac3f2e5b9f58110f85db893e83a332751192682
   languageName: node
   linkType: hard
 
@@ -1202,29 +1206,30 @@ __metadata:
   linkType: hard
 
 "eslint-plugin-n@npm:^17.15.1":
-  version: 17.18.0
-  resolution: "eslint-plugin-n@npm:17.18.0"
+  version: 17.21.3
+  resolution: "eslint-plugin-n@npm:17.21.3"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.5.0"
     enhanced-resolve: "npm:^5.17.1"
     eslint-plugin-es-x: "npm:^7.8.0"
     get-tsconfig: "npm:^4.8.1"
     globals: "npm:^15.11.0"
+    globrex: "npm:^0.1.2"
     ignore: "npm:^5.3.2"
-    minimatch: "npm:^9.0.5"
     semver: "npm:^7.6.3"
+    ts-declaration-location: "npm:^1.0.6"
   peerDependencies:
     eslint: ">=8.23.0"
-  checksum: 10c0/ba2d624036a55be6f713b4e5bb6b015045abbcdbc328a2d9a384eb79f8e5ce062d8eafb14d8711bd283b5102cbf57ffad11a79bb563c94c881b11c4cf795783b
+  checksum: 10c0/3d8b279aaf477ddde06f9b63f032e22da3d3c1edda75ff509c93a871fc36bbdd7e1005403113f2bc421d970d52e2c361f69d05a2bfbad14146c16f910952a764
   languageName: node
   linkType: hard
 
 "eslint-plugin-prettier@npm:^5.2.3":
-  version: 5.4.0
-  resolution: "eslint-plugin-prettier@npm:5.4.0"
+  version: 5.5.4
+  resolution: "eslint-plugin-prettier@npm:5.5.4"
   dependencies:
     prettier-linter-helpers: "npm:^1.0.0"
-    synckit: "npm:^0.11.0"
+    synckit: "npm:^0.11.7"
   peerDependencies:
     "@types/eslint": ">=8.0.0"
     eslint: ">=8.0.0"
@@ -1235,7 +1240,7 @@ __metadata:
       optional: true
     eslint-config-prettier:
       optional: true
-  checksum: 10c0/50718d16266dfbe6909697f9d7c9188d2664f5be50fa1de4decc0c8236565570823fdf5973f89cd51254af5551b6160650e092716002a62aaa0f0b2c18e8fc3e
+  checksum: 10c0/5cc780e0ab002f838ad8057409e86de4ff8281aa2704a50fa8511abff87028060c2e45741bc9cbcbd498712e8d189de8026e70aed9e20e50fe5ba534ee5a8442
   languageName: node
   linkType: hard
 
@@ -1249,13 +1254,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^8.3.0":
-  version: 8.3.0
-  resolution: "eslint-scope@npm:8.3.0"
+"eslint-scope@npm:^8.4.0":
+  version: 8.4.0
+  resolution: "eslint-scope@npm:8.4.0"
   dependencies:
     esrecurse: "npm:^4.3.0"
     estraverse: "npm:^5.2.0"
-  checksum: 10c0/23bf54345573201fdf06d29efa345ab508b355492f6c6cc9e2b9f6d02b896f369b6dd5315205be94b8853809776c4d13353b85c6b531997b164ff6c3328ecf5b
+  checksum: 10c0/407f6c600204d0f3705bd557f81bd0189e69cd7996f408f8971ab5779c0af733d1af2f1412066b40ee1588b085874fc37a2333986c6521669cdbdd36ca5058e0
   languageName: node
   linkType: hard
 
@@ -1266,25 +1271,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "eslint-visitor-keys@npm:4.2.0"
-  checksum: 10c0/2ed81c663b147ca6f578312919483eb040295bbab759e5a371953456c636c5b49a559883e2677112453728d66293c0a4c90ab11cab3428cf02a0236d2e738269
+"eslint-visitor-keys@npm:^4.2.0, eslint-visitor-keys@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "eslint-visitor-keys@npm:4.2.1"
+  checksum: 10c0/fcd43999199d6740db26c58dbe0c2594623e31ca307e616ac05153c9272f12f1364f5a0b1917a8e962268fdecc6f3622c1c2908b4fcc2e047a106fe6de69dc43
   languageName: node
   linkType: hard
 
 "eslint@npm:^9.27.0":
-  version: 9.27.0
-  resolution: "eslint@npm:9.27.0"
+  version: 9.33.0
+  resolution: "eslint@npm:9.33.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.2.0"
     "@eslint-community/regexpp": "npm:^4.12.1"
-    "@eslint/config-array": "npm:^0.20.0"
-    "@eslint/config-helpers": "npm:^0.2.1"
-    "@eslint/core": "npm:^0.14.0"
+    "@eslint/config-array": "npm:^0.21.0"
+    "@eslint/config-helpers": "npm:^0.3.1"
+    "@eslint/core": "npm:^0.15.2"
     "@eslint/eslintrc": "npm:^3.3.1"
-    "@eslint/js": "npm:9.27.0"
-    "@eslint/plugin-kit": "npm:^0.3.1"
+    "@eslint/js": "npm:9.33.0"
+    "@eslint/plugin-kit": "npm:^0.3.5"
     "@humanfs/node": "npm:^0.16.6"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
     "@humanwhocodes/retry": "npm:^0.4.2"
@@ -1295,9 +1300,9 @@ __metadata:
     cross-spawn: "npm:^7.0.6"
     debug: "npm:^4.3.2"
     escape-string-regexp: "npm:^4.0.0"
-    eslint-scope: "npm:^8.3.0"
-    eslint-visitor-keys: "npm:^4.2.0"
-    espree: "npm:^10.3.0"
+    eslint-scope: "npm:^8.4.0"
+    eslint-visitor-keys: "npm:^4.2.1"
+    espree: "npm:^10.4.0"
     esquery: "npm:^1.5.0"
     esutils: "npm:^2.0.2"
     fast-deep-equal: "npm:^3.1.3"
@@ -1319,18 +1324,18 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10c0/135d301e37cd961000a9c1d3f0e1863bed29a61435dfddedba3db295973193024382190fd8790a8de83777d10f450082a29eaee8bc9ce0fb1bc1f2b0bb882280
+  checksum: 10c0/1e1f60d2b62d9d65553e9af916a8dccf00eeedd982103f35bf58c205803907cb1fda73ef595178d47384ea80d8624a182b63682a6b15d8387e9a5d86904a2a2d
   languageName: node
   linkType: hard
 
-"espree@npm:^10.0.1, espree@npm:^10.3.0":
-  version: 10.3.0
-  resolution: "espree@npm:10.3.0"
+"espree@npm:^10.0.1, espree@npm:^10.3.0, espree@npm:^10.4.0":
+  version: 10.4.0
+  resolution: "espree@npm:10.4.0"
   dependencies:
-    acorn: "npm:^8.14.0"
+    acorn: "npm:^8.15.0"
     acorn-jsx: "npm:^5.3.2"
-    eslint-visitor-keys: "npm:^4.2.0"
-  checksum: 10c0/272beeaca70d0a1a047d61baff64db04664a33d7cfb5d144f84bc8a5c6194c6c8ebe9cc594093ca53add88baa23e59b01e69e8a0160ab32eac570482e165c462
+    eslint-visitor-keys: "npm:^4.2.1"
+  checksum: 10c0/c63fe06131c26c8157b4083313cb02a9a54720a08e21543300e55288c40e06c3fc284bdecf108d3a1372c5934a0a88644c98714f38b6ae8ed272b40d9ea08d6b
   languageName: node
   linkType: hard
 
@@ -1595,6 +1600,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"globrex@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "globrex@npm:0.1.2"
+  checksum: 10c0/a54c029520cf58bda1d8884f72bd49b4cd74e977883268d931fd83bcbd1a9eb96d57c7dbd4ad80148fb9247467ebfb9b215630b2ed7563b2a8de02e1ff7f89d1
+  languageName: node
+  linkType: hard
+
 "graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
@@ -1633,9 +1645,9 @@ __metadata:
   linkType: hard
 
 "ignore@npm:^7.0.0":
-  version: 7.0.4
-  resolution: "ignore@npm:7.0.4"
-  checksum: 10c0/90e1f69ce352b9555caecd9cbfd07abe7626d312a6f90efbbb52c7edca6ea8df065d66303863b30154ab1502afb2da8bc59d5b04e1719a52ef75bbf675c488eb
+  version: 7.0.5
+  resolution: "ignore@npm:7.0.5"
+  checksum: 10c0/ae00db89fe873064a093b8999fe4cc284b13ef2a178636211842cceb650b9c3e390d3339191acb145d81ed5379d2074840cf0c33a20bdbd6f32821f79eb4ad5d
   languageName: node
   linkType: hard
 
@@ -1931,7 +1943,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.4, minimatch@npm:^9.0.5":
+"minimatch@npm:^9.0.4":
   version: 9.0.5
   resolution: "minimatch@npm:9.0.5"
   dependencies:
@@ -1972,7 +1984,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.8":
+"nanoid@npm:^3.3.11":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
   bin:
@@ -2171,9 +2183,9 @@ __metadata:
   linkType: hard
 
 "picomatch@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "picomatch@npm:4.0.2"
-  checksum: 10c0/7c51f3ad2bb42c776f49ebf964c644958158be30d0a510efd5a395e8d49cb5acfed5b82c0c5b365523ce18e6ab85013c9ebe574f60305892ec3fa8eee8304ccc
+  version: 4.0.3
+  resolution: "picomatch@npm:4.0.3"
+  checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
   languageName: node
   linkType: hard
 
@@ -2203,17 +2215,17 @@ __metadata:
   linkType: hard
 
 "prettier@npm:^3.5.3":
-  version: 3.5.3
-  resolution: "prettier@npm:3.5.3"
+  version: 3.6.2
+  resolution: "prettier@npm:3.6.2"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10c0/3880cb90b9dc0635819ab52ff571518c35bd7f15a6e80a2054c05dbc8a3aa6e74f135519e91197de63705bcb38388ded7e7230e2178432a1468005406238b877
+  checksum: 10c0/488cb2f2b99ec13da1e50074912870217c11edaddedeadc649b1244c749d15ba94e846423d062e2c4c9ae683e2d65f754de28889ba06e697ac4f988d44f45812
   languageName: node
   linkType: hard
 
 "protobufjs@npm:^7.2.5":
-  version: 7.5.3
-  resolution: "protobufjs@npm:7.5.3"
+  version: 7.5.4
+  resolution: "protobufjs@npm:7.5.4"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -2227,7 +2239,7 @@ __metadata:
     "@protobufjs/utf8": "npm:^1.1.0"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
-  checksum: 10c0/9dc131a7e7a610b8291a0b0033b313f8754ef419b57c44d27874dd4edf1afc2a9a77d7a5bc2df9a744cba014de67c92756759c73200b702a11f13360e907b0dd
+  checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
   languageName: node
   linkType: hard
 
@@ -2480,12 +2492,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"synckit@npm:^0.11.0":
-  version: 0.11.6
-  resolution: "synckit@npm:0.11.6"
+"synckit@npm:^0.11.7":
+  version: 0.11.11
+  resolution: "synckit@npm:0.11.11"
   dependencies:
-    "@pkgr/core": "npm:^0.2.4"
-  checksum: 10c0/51c0e41c025b90cc68a7b304fbfe873cc77b3ddc99e92ab33fbd42f4fbd1ee65fc7d9affd8eedcac43644658399244aa521e19fb18d7b4e66898d0e2c0cc8d9b
+    "@pkgr/core": "npm:^0.2.9"
+  checksum: 10c0/f0761495953d12d94a86edf6326b3a565496c72f9b94c02549b6961fb4d999f4ca316ce6b3eb8ed2e4bfc5056a8de65cda0bd03a233333a35221cd2fdc0e196b
   languageName: node
   linkType: hard
 
@@ -2533,8 +2545,8 @@ __metadata:
   linkType: hard
 
 "terser@npm:^5.31.1":
-  version: 5.40.0
-  resolution: "terser@npm:5.40.0"
+  version: 5.43.1
+  resolution: "terser@npm:5.43.1"
   dependencies:
     "@jridgewell/source-map": "npm:^0.3.3"
     acorn: "npm:^8.14.0"
@@ -2542,7 +2554,7 @@ __metadata:
     source-map-support: "npm:~0.5.20"
   bin:
     terser: bin/terser
-  checksum: 10c0/0a6f35085217299b2e93c4c97533267f0d3a151fa771d7903bba3466345511c1ada2c474c668fc27f67b52906abac12fcf65b537dc5c177a1be9230aaa159b7f
+  checksum: 10c0/9cd3fa09ea6bcb79eb71995216b8bef0651b18c5c3877535fc699a77e1ab43b140a4da5811ac9baeb654fa9ec939b17324092f0f0bdb19c402e101e3db946986
   languageName: node
   linkType: hard
 
@@ -2564,6 +2576,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-declaration-location@npm:^1.0.6":
+  version: 1.0.7
+  resolution: "ts-declaration-location@npm:1.0.7"
+  dependencies:
+    picomatch: "npm:^4.0.2"
+  peerDependencies:
+    typescript: ">=4.0.0"
+  checksum: 10c0/b579b7630907052cc174b051dffdb169424824d887d8fb5abdc61e7ab0eede348c2b71c998727b9e4b314c0436f5003a15bb7eedb1c851afe96e12499f159630
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
@@ -2581,29 +2604,29 @@ __metadata:
   linkType: hard
 
 "typescript@npm:^5.8.3":
-  version: 5.8.3
-  resolution: "typescript@npm:5.8.3"
+  version: 5.9.2
+  resolution: "typescript@npm:5.9.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/5f8bb01196e542e64d44db3d16ee0e4063ce4f3e3966df6005f2588e86d91c03e1fb131c2581baf0fb65ee79669eea6e161cd448178986587e9f6844446dbb48
+  checksum: 10c0/cd635d50f02d6cf98ed42de2f76289701c1ec587a363369255f01ed15aaf22be0813226bff3c53e99d971f9b540e0b3cc7583dbe05faded49b1b0bed2f638a18
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@npm%3A^5.8.3#optional!builtin<compat/typescript>":
-  version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=cef18b"
+  version: 5.9.2
+  resolution: "typescript@patch:typescript@npm%3A5.9.2#optional!builtin<compat/typescript>::version=5.9.2&hash=cef18b"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/92ea03509e06598948559ddcdd8a4ae5a7ab475766d5589f1b796f5731b3d631a4c7ddfb86a3bd44d58d10102b132cd4b4994dda9b63e6273c66d77d6a271dbd
+  checksum: 10c0/66fc07779427a7c3fa97da0cf2e62595eaff2cea4594d45497d294bfa7cb514d164f0b6ce7a5121652cf44c0822af74e29ee579c771c405e002d1f23cf06bfde
   languageName: node
   linkType: hard
 
-"undici-types@npm:~6.21.0":
-  version: 6.21.0
-  resolution: "undici-types@npm:6.21.0"
-  checksum: 10c0/c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
+"undici-types@npm:~7.10.0":
+  version: 7.10.0
+  resolution: "undici-types@npm:7.10.0"
+  checksum: 10c0/8b00ce50e235fe3cc601307f148b5e8fb427092ee3b23e8118ec0a5d7f68eca8cee468c8fc9f15cbb2cf2a3797945ebceb1cbd9732306a1d00e0a9b6afa0f635
   languageName: node
   linkType: hard
 
@@ -2688,27 +2711,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-sources@npm:^3.2.3":
-  version: 3.3.0
-  resolution: "webpack-sources@npm:3.3.0"
-  checksum: 10c0/d9366eef6db95dffe154b6ffb50424c34f42d51ba3441efe9134642d13b0ccdf43897bdc7742f9f58eb4e834378f7ff67596137d3fca21ce34fe7cee8796e97a
+"webpack-sources@npm:^3.3.3":
+  version: 3.3.3
+  resolution: "webpack-sources@npm:3.3.3"
+  checksum: 10c0/ab732f6933b513ba4d505130418995ddef6df988421fccf3289e53583c6a39e205c4a0739cee98950964552d3006604912679c736031337fb4a9d78d8576ed40
   languageName: node
   linkType: hard
 
 "webpack@npm:^5.97.1":
-  version: 5.99.9
-  resolution: "webpack@npm:5.99.9"
+  version: 5.101.3
+  resolution: "webpack@npm:5.101.3"
   dependencies:
     "@types/eslint-scope": "npm:^3.7.7"
-    "@types/estree": "npm:^1.0.6"
+    "@types/estree": "npm:^1.0.8"
     "@types/json-schema": "npm:^7.0.15"
     "@webassemblyjs/ast": "npm:^1.14.1"
     "@webassemblyjs/wasm-edit": "npm:^1.14.1"
     "@webassemblyjs/wasm-parser": "npm:^1.14.1"
-    acorn: "npm:^8.14.0"
+    acorn: "npm:^8.15.0"
+    acorn-import-phases: "npm:^1.0.3"
     browserslist: "npm:^4.24.0"
     chrome-trace-event: "npm:^1.0.2"
-    enhanced-resolve: "npm:^5.17.1"
+    enhanced-resolve: "npm:^5.17.3"
     es-module-lexer: "npm:^1.2.1"
     eslint-scope: "npm:5.1.1"
     events: "npm:^3.2.0"
@@ -2722,13 +2746,13 @@ __metadata:
     tapable: "npm:^2.1.1"
     terser-webpack-plugin: "npm:^5.3.11"
     watchpack: "npm:^2.4.1"
-    webpack-sources: "npm:^3.2.3"
+    webpack-sources: "npm:^3.3.3"
   peerDependenciesMeta:
     webpack-cli:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 10c0/34ec3f19b50bccaf27929e5e5b901b25047f2d414acba7d0967dc98eb4f404d107fb1a4b63095edbca2b006ff5815f1720b131e10b20664b074dfc86b7ffa717
+  checksum: 10c0/3c204d4f1df0ef2774ae043f62e4db56c11b7a0594e82fbb1fbbaf69893570f3bf08a8b5d2d5a0302ce6346132bf3eb9dbde81e4fab3d68307b2e506d606f064
   languageName: node
   linkType: hard
 
@@ -2819,10 +2843,10 @@ __metadata:
   linkType: hard
 
 "zx@npm:^8.3.2":
-  version: 8.5.4
-  resolution: "zx@npm:8.5.4"
+  version: 8.8.0
+  resolution: "zx@npm:8.8.0"
   bin:
     zx: build/cli.js
-  checksum: 10c0/073bd39ba46d278c8bfb72df641a6eed409974633cf5195fc1d5148517c454319e35413eb8076821928d02a1ae5a4f863147712c538e61fe0a4b78c0e01a10be
+  checksum: 10c0/e183a6ab5a3b6645f05fc0f5174c420b25a826a1be6e337dbf4032074d63379cd2f8025ed28362514cf24cf03f0736786f09b59e3ef09fefd7b128ccffdcbeb7
   languageName: node
   linkType: hard


### PR DESCRIPTION
This pull request adds actions, feedbacks and variables for cuelists.

Added (also documented in HELP.md)
- Actions: Set intensity/fade factor/speed factor, Run action, Set play mode
- Feedbacks: Check state, Previous/Current/Next cue, Cue progress reached
- Variables: see HELP.md

Also added the possibility to `RepositoryBase` to create a element selection field with a dropdown or a text field supporting variables to allow for more flexibility in element selection and the possibility to reuse the input field code.

Additional changes:
- Updated `@companion-module/base` to 0.12.0 to be able to dynamically show/hide fields
- Small refactor in `GRPCClient` to allow the clients to trigger an update to their actions, feedbacks and variables (in the same way as was already possible for presets) to be able to update available options e.g. cuelists in selection dropdown


Attached: 
[A (quick and dirty) DMXC-Project file (dmxc_companion_test_project.zip; not .dmz as GitHub doesn' allow that)](https://github.com/user-attachments/files/24389932/dmxc_companion_test_project.zip)
 with two cuelistst and 
[a companion page config (dmxc_test.json, needs to be renamed to . companion also dur to GitHub restrictions)](https://github.com/user-attachments/files/24389934/dmxc_test.json) interacting with the former
